### PR TITLE
Fix undocumented filament load/unload exit; screen tells you to press th...

### DIFF
--- a/firmware/src/MightyBoard/shared/Menu.cc
+++ b/firmware/src/MightyBoard/shared/Menu.cc
@@ -694,7 +694,7 @@ void FilamentScreen::update(LiquidCrystalSerial& lcd, bool forceRedraw) {
 		case FILAMENT_DONE:
 			/// user indicated that filament has extruded
 			stopMotor();
-			Motherboard::interfaceBlinkOn();
+			Motherboard::interfaceBlinkOff();
 			_delay_us(1000000);
 			break;
 		case FILAMENT_TIMEOUT:
@@ -2951,6 +2951,7 @@ void CancelBuildMenu::handleSelect(uint8_t index) {
 		break;
 	case 3:
 		// Cancel build
+	        filamentScreen.filamentState = FILAMENT_DONE;
 		if ( state != 0 ) {
 			// We're merely paused while printing
 			interface::popScreen();

--- a/firmware/src/MightyBoard/shared/Menu.hh
+++ b/firmware/src/MightyBoard/shared/Menu.hh
@@ -232,11 +232,12 @@ public:
 
 	void notifyButtonPressed(ButtonArray::ButtonName button);
 
+	uint8_t filamentState;
+
 private:
 	Timeout filamentTimer;
 	int16_t filamentTemp[EXTRUDERS];
 	int16_t setTemp;
-	uint8_t filamentState;
 	uint8_t axisID, toolID;
 	uint8_t digiPotOnEntry;
 	uint8_t restoreAxesEnabled;


### PR DESCRIPTION
...e "M" to exit and that works.  But if you used the LEFT button, then it sort of works but doesn't cancel the motor
