### PR TITLE
Apparently libc for ARM has a known issue whereby getopt() returns a 1 byt...

### DIFF
--- a/firmware/simulator/planner.cc
+++ b/firmware/simulator/planner.cc
@@ -57,6 +57,12 @@ static ssize_t display(void *ctx_, unsigned char *str, size_t len)
      return(0);
 }
 
+#if defined(__arm__)
+#define GETOPTS_END (char)-1
+#else
+#define GETOPTS_END -1
+#endif
+
 #if defined(SAILTIME)
 #define PROGNAME "sailtime"
 #define OPTIONS "[-? | -h] [-a x,y,z,a,b] [-c x,y,z,a,b]"
@@ -124,7 +130,7 @@ int main(int argc, const char *argv[])
      simulator_dump_speeds = false;
      simulator_show_alt_feed_rate = false;
 
-     while ((c = getopt(argc, (char **)argv, GETOPTS)) != -1)
+     while ((c = getopt(argc, (char **)argv, GETOPTS)) != GETOPTS_END)
      {
 	  switch(c)
 	  {

--- a/firmware/simulator/s3gdump.c
+++ b/firmware/simulator/s3gdump.c
@@ -12,6 +12,12 @@
 #include <math.h>
 #include "s3g.h"
 
+#if defined(__arm__)
+#define GETOPTS_END (char)-1
+#else
+#define GETOPTS_END -1
+#endif
+
 static void usage(FILE *f, const char *prog)
 {
      if (f == NULL)
@@ -204,7 +210,7 @@ int main(int argc, const char *argv[])
      int do_edensity;
 
      do_edensity = 0;
-     while ((c = getopt(argc, (char **)argv, ":hE?")) != -1)
+     while ((c = getopt(argc, (char **)argv, ":hE?")) != GETOPTS_END)
      {
 	  switch(c)
 	  {


### PR DESCRIPTION
...e char instead of a traditional int char.  This makes checking for a return of -1 from getopt() not work; has to be (char)-1.  Issue arose on Raspberry Pi
