### PR TITLE
corrected virtual member functions for derived classes in Menu.hh

### DIFF
--- a/firmware/src/MightyBoard/shared/Menu.hh
+++ b/firmware/src/MightyBoard/shared/Menu.hh
@@ -107,15 +107,15 @@ class Menu: public Screen {
 public:
 	Menu(uint8_t optionsMask, uint8_t count): Screen(optionsMask), itemCount(count) {}
 
-	micros_t getUpdateRate() {return 500L * 1000L;}
+	virtual micros_t getUpdateRate() {return 500L * 1000L;}
 
-	void update(LiquidCrystalSerial& lcd, bool forceRedraw);
+	virtual void update(LiquidCrystalSerial& lcd, bool forceRedraw);
 
-	void reset();
+	virtual void reset();
 
 	virtual void resetState();
 
-        void notifyButtonPressed(ButtonArray::ButtonName button);
+    virtual void notifyButtonPressed(ButtonArray::ButtonName button);
 
 protected:
 
@@ -144,9 +144,9 @@ class CounterMenu: public Menu {
 public:
 	CounterMenu(uint8_t optionsMask, uint8_t count): Menu(optionsMask, count) {}
 
-	micros_t getUpdateRate() {return 200L * 1000L;}
+	virtual micros_t getUpdateRate() {return 200L * 1000L;}
 
-	void notifyButtonPressed(ButtonArray::ButtonName button);
+	virtual void notifyButtonPressed(ButtonArray::ButtonName button);
 
 protected:
 	bool selectMode;        ///< true if in counter change state
@@ -154,11 +154,11 @@ protected:
 	uint8_t firstSelectIndex;   ///< first line with selectable item
 	uint8_t lastSelectIndex;   ///< last line with a selectable item
 
-	void reset();
+	virtual void reset();
 
     // must be virtual for derived classes
-	virtual void drawItem(uint8_t index, LiquidCrystalSerial& lcd) { }
-	virtual void handleCounterUpdate(uint8_t index, int8_t up) { }
+	virtual void drawItem(uint8_t index, LiquidCrystalSerial& lcd) = 0;
+	virtual void handleCounterUpdate(uint8_t index, int8_t up) = 0;
 };
 
 /// Display a welcome splash screen, that removes itself when updated.


### PR DESCRIPTION
some corrections, does not change anything in the binary.
some problems in the settings menu with cursor exists.

I build mighty_twox: .
I tested with avr-g++-4.9.0 with the same libc, it works fine, but it is not for distribution as there some differences in sizes.

text      data    bss
124929 1270  5522     avr-g++-4.6.2
107974 1006  5522     avr-g++-4.9.0