### PR TITLE
To jetty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ documentation
 NOTES.TXT
 *.log
 *.sh~
-DarwinObj/*.pyc
+*.pyc

--- a/firmware/src/MightyBoard/shared/Menu.cc
+++ b/firmware/src/MightyBoard/shared/Menu.cc
@@ -3167,6 +3167,7 @@ void ActiveBuildMenu::handleSelect(uint8_t index) {
 		// Do not bother setting EEPROM values
 		RGB_LED::setDefaultColor(LEDColor);
 	}
+	lind++;
 #endif
 
 	if ( index == lind ) {


### PR DESCRIPTION
basically stuff I found strange

1. *.pyc are compiled python scripts, they should be ignored by git.
2. commit b9e761a9d55974182f83e34e2abf3fdf2b4b856c adds RGB LED on/off support whilst printing, but doesn't advance the menu index counter. this renders "Print Statistics" and "Cold Pause" malfunction, "Print Statistics" just becomes "Cold Pause", and "Cold Pause" simply does nothing. this commit fix it.