### PR TITLE
Enable more gcc warnings with -Wextra.

### DIFF
--- a/firmware/src/SConscript.mightyboard
+++ b/firmware/src/SConscript.mightyboard
@@ -155,6 +155,7 @@ flags=[
 	'-g',
 	'-Os',
 	'-Wall',
+	'-Wextra',
 	'-Winline',
 	'-Wno-deprecated-declarations',
 	'-fno-exceptions',


### PR DESCRIPTION
This enables most of the warnings from gcc. Only -pedantic is not activated.