### PR TITLE
move machine dependent values to platforms.py

### DIFF
--- a/firmware/src/MightyBoard/Motherboard/EepromMap.cc
+++ b/firmware/src/MightyBoard/Motherboard/EepromMap.cc
@@ -323,10 +323,19 @@ void factoryResetEEPROM()
 #endif
 {
 
+#if !defined(PLATFORM_ENDSTOP_INVERT)
 	// Default: enstops inverted, Z axis inverted
 	uint8_t endstop_invert = 0b10011111; // all endstops inverted
+#else
+	uint8_t endstop_invert = PLATFORM_ENDSTOP_INVERT;
+#endif
 
-	uint8_t home_direction = 0b11011; // X,Y Max, Z min  (AB max - to never halt on edge in stepper interface)
+#if !defined(PLATFORM_HOME_DIRECTION)
+	// X,Y Max, Z min  (AB max - to never halt on edge in stepper interface)
+	uint8_t home_direction = 0b11011;
+#else
+	uint8_t home_direction = PLATFORM_HOME_DIRECTION;
+#endif
 
 	uint8_t vRefBase[] = { X_POT_DEFAULT,
 			       Y_POT_DEFAULT,
@@ -536,7 +545,11 @@ enum BOTSTEP_TYPE {
 void fullResetEEPROM() {
 
 	// axis inversion settings
+#if !defined(PLATFORM_AXIS_INVERT)
 	uint8_t axis_invert = 0b10111; // invert XYBZ
+#else
+	uint8_t axis_invert = PLATFORM_AXIS_INVERT;
+#endif
 	eeprom_write_byte((uint8_t*)eeprom_offsets::AXIS_INVERSION, axis_invert);
 
 	// tool count settings

--- a/firmware/src/MightyBoard/Motherboard/EepromMap.hh
+++ b/firmware/src/MightyBoard/Motherboard/EepromMap.hh
@@ -121,52 +121,17 @@ const static uint16_t D_TERM_OFFSET = 4;
  *  and the ideal 'center' of the toolhead system, in steps
  */
 namespace replicator_axis_offsets{
-#if 0
-	const static uint32_t DUAL_X_OFFSET_MM = 152L;
-	const static uint32_t SINGLE_X_OFFSET_MM = 152L;
-	const static uint32_t DUAL_Y_OFFSET_MM = 75L;
-	const static uint32_t SINGLE_Y_OFFSET_MM = 72L;
-#endif
-#ifdef ZYYX_3D_PRINTER
-	const static uint32_t DUAL_X_OFFSET_STEPS   = 11957L; // 135*88.573186;
-	const static uint32_t SINGLE_X_OFFSET_STEPS = 11957L; // 135*88.573186;
-	const static uint32_t DUAL_Y_OFFSET_STEPS   = 10186L; // 115*88.573186;
-	const static uint32_t SINGLE_Y_OFFSET_STEPS = 10186L; // 115*88.573186;
-#elif BOARD_TYPE == BOARD_TYPE_AZTEEG_X3
-#ifndef XY_MIN_HOMING
-	// Use Rep 1 defaults
-	const static uint32_t DUAL_X_OFFSET_STEPS   = 14309L;
-	const static uint32_t SINGLE_X_OFFSET_STEPS = 14309L;
-	const static uint32_t DUAL_Y_OFFSET_STEPS   =  7060L;
-	const static uint32_t SINGLE_Y_OFFSET_STEPS =  6778L;
+#if !defined(PLATFORM_AXIS_OFFSETS)
+	const static uint32_t axis_offsets[] = {14309L, 14309L, 7060L, 6770L};
 #else
-	// Use (0, 0) for the default home position when homing XY-min
-	const static uint32_t DUAL_X_OFFSET_STEPS   = 0L;
-	const static uint32_t SINGLE_X_OFFSET_STEPS = 0L;
-	const static uint32_t DUAL_Y_OFFSET_STEPS   = 0L;
-	const static uint32_t SINGLE_Y_OFFSET_STEPS = 0L;
+	const static uint32_t axis_offsets[] = PLATFORM_AXIS_OFFSETS;
 #endif
-#elif CLONE_R1
-	const static uint32_t DUAL_X_OFFSET_STEPS   = 14444L; // 162.5*88.8889;
-	const static uint32_t SINGLE_X_OFFSET_STEPS = 14444L; // 162.5*88.8889;
-	const static uint32_t DUAL_Y_OFFSET_STEPS   =  8667L; //  97.5*88.8889;
-	const static uint32_t SINGLE_Y_OFFSET_STEPS =  8667L; //  97.5*88.8889;
-#elif MODEL_REPLICATOR2
-	const static uint32_t DUAL_X_OFFSET_STEPS   = 13463L;
-	const static uint32_t SINGLE_X_OFFSET_STEPS = 13463L;
-	const static uint32_t DUAL_Y_OFFSET_STEPS   =  6643L;
-	const static uint32_t SINGLE_Y_OFFSET_STEPS =  6377L;
-#elif WANHAO_DUP4
-	const static uint32_t DUAL_X_OFFSET_STEPS   = 13763L; // 146.2 mm
-	const static uint32_t SINGLE_X_OFFSET_STEPS = 13763L;
-	const static uint32_t DUAL_Y_OFFSET_STEPS   =  6919L; //  73.5 mm
-	const static uint32_t SINGLE_Y_OFFSET_STEPS =  6919L;
-#else
-	const static uint32_t DUAL_X_OFFSET_STEPS   = 14309L;
-	const static uint32_t SINGLE_X_OFFSET_STEPS = 14309L;
-	const static uint32_t DUAL_Y_OFFSET_STEPS   =  7060L;
-	const static uint32_t SINGLE_Y_OFFSET_STEPS =  6778L;
-#endif
+
+	const static uint32_t DUAL_X_OFFSET_STEPS	= axis_offsets[0];
+	const static uint32_t SINGLE_X_OFFSET_STEPS	= axis_offsets[1];
+	const static uint32_t DUAL_Y_OFFSET_STEPS	= axis_offsets[2];
+	const static uint32_t SINGLE_Y_OFFSET_STEPS	= axis_offsets[3];
+
 	/// Footnote:
 	/// mm offsets
 	/// XDUAL: 152mm,
@@ -181,44 +146,32 @@ namespace replicator_axis_offsets{
 }
 
 namespace replicator_axis_lengths{
+#if !defined(PLATFORM_AXIS_LENGTHS)
 	// These are the maximum lengths of all axis, and are populated from Replicator G
 	// on connection.  These are reasonable defaults for X/Y/Z/A/B
 	// Each one is the length(in mm's) * steps_per_mm  (from the xml file and the result is rounded down)
-#ifdef ZYYX_3D_PRINTER
-     // ZYYX 3D Printer
-     const static uint32_t axis_lengths[5] = {270L, 230L, 195L, 100000L, 100000L};
-#elif CLONE_R1
-     const static uint32_t axis_lengths[5] = {300L, 195L, 210L, 100000L, 100000L};
-#elif MODEL_REPLICATOR
-    // Replicator 1
-    const static uint32_t axis_lengths[5] = {227L, 148L, 150L, 100000L, 100000L};
+	const static uint32_t axis_lengths[5] = {227L, 148L, 150L, 100000L, 100000L};
 #else
-#ifdef SINGLE_EXTRUDER
-    // Replicator 2
-    const static uint32_t axis_lengths[5] = {285L, 152L, 155L, 100000L, 100000L};
-#else
-    // Replicator 2X
-    const static uint32_t axis_lengths[5] = {246L, 152L, 155L, 100000L, 100000L};
-#endif
+	const static uint32_t axis_lengths[5] = PLATFORM_AXIS_LENGTHS;
 #endif
 }
 
 namespace replicator_axis_max_feedrates{
+#if !defined(PLATFORM_MAX_FEEDRATES)
 	// These are the maximum feedrates of all axis, and are populated from Replicator G
 	// on connection.  These are reasonable defaults for X/Y/Z/A/B
 	// Each one is the feedrate in mm per minute (extruders are the feedrate of the input filament)
 	const static uint32_t axis_max_feedrates[5] = {18000, 18000, 1170, 1600, 1600};
+#else
+	const static uint32_t axis_max_feedrates[5] = PLATFORM_MAX_FEEDRATES;
+#endif
 }
 
 namespace replicator_axis_steps_per_mm{
-#ifdef ZYYX_3D_PRINTER
-	const static uint32_t axis_steps_per_mm[5] = { 88573186, 88573186, 400000000, 96275202, 96275202};
-#elif CLONE_R1
-	const static uint32_t axis_steps_per_mm[5] = { 88888889, 88888889, 400000000, 96275202, 96275202};
-#elif MODEL_REPLICATOR2
-	const static uint32_t axis_steps_per_mm[5] = { 88573186, 88573186, 400000000, 96275202, 96275202};
-#else
+#if !defined(PLATFORM_AXIS_STEPS_PER_MM)
 	const static uint32_t axis_steps_per_mm[5] = { 94139704, 94139704, 400000000, 96275202, 96275202};
+#else
+	const static uint32_t axis_steps_per_mm[5] = PLATFORM_AXIS_STEPS_PER_MM;
 #endif
 
 	/// Footnote:

--- a/firmware/src/MightyBoard/Motherboard/MachineId.hh
+++ b/firmware/src/MightyBoard/Motherboard/MachineId.hh
@@ -1,78 +1,22 @@
 #ifndef MACHINEID_HH_
 #define MACHINEID_HH_
 
-#ifdef THE_REPLICATOR_STR
-#undef THE_REPLICATOR_STR
-#endif
-
-#ifdef MACHINE_ID
-#undef MACHINE_ID
-#endif
-
-#ifdef ZYYX_3D_PRINTER
-
-#define THE_REPLICATOR_STR "ZYYX 3D Printer"
-#define MACHINE_ID 0xD314 // Replicator 1
-
-#elif CLONE_R1
-
-#define THE_REPLICATOR_STR "CloneR1"
-#define MACHINE_ID 0xD314 // Replicator 1
-
-#elif AZTEEG_X3
-
-#define THE_REPLICATOR_STR "Azteeg X3"
-#define MACHINE_ID 0xD314 // Replicator 1
-
-#elif FF_CREATOR
-
-#define THE_REPLICATOR_STR "FF Creator"
-#define MACHINE_ID 0xD314 // Replicator 1
-
-#elif FF_CREATOR_X
-
-#define THE_REPLICATOR_STR "Creator X / Pro"
-#define MACHINE_ID 0xD314 // Replicator 1
-
-#elif WANHAO_DUP4
-
-#define THE_REPLICATOR_STR "Wanhao Duplicatr"
-#define MACHINE_ID 0xD314 // Replicator 1
-
-#elif MODEL_REPLICATOR
-
-#define THE_REPLICATOR_STR "The Replicator"
-#define MACHINE_ID 0xD314 // Replicator 1
-
-#elif MODEL_REPLICATOR2
-#if defined(SINGLE_EXTRUDER)
-
-#define THE_REPLICATOR_STR "Replicator 2"
-#define MACHINE_ID 0xB015 // Replicator 2
-
+#if !defined(PLATFORM_THE_REPLICATOR_STR)
+#define THE_REPLICATOR_STR "Sailfish Replicator"
 #else
-
-#define THE_REPLICATOR_STR "Replicator 2X"
-#define MACHINE_ID 0xB017 // Replicator 2X
-
+#define THE_REPLICATOR_STR PLATFORM_THE_REPLICATOR_STR
 #endif
-#else
 
-#define THE_REPLICATOR_STR "Makerbot"
+#if !defined(PLATFORM_MACHINE_ID)
 #define MACHINE_ID 0xD314 // Replicator 1
-
-#endif
-
-#ifdef TOOLHEAD_OFFSET_X
-#undef TOOLHEAD_OFFSET_X
-#endif
-
-#if defined(FF_CREATOR) || defined(FF_CREATOR_X)
-#define TOOLHEAD_OFFSET_X 34.0
-#elif defined(MODEL_REPLICATOR2)
-#define TOOLHEAD_OFFSET_X 35.0
 #else
+#define MACHINE_ID PLATFORM_MACHINE_ID
+#endif
+
+#if !defined(PLATFORM_TOOLHEAD_OFFSET_X)
 #define TOOLHEAD_OFFSET_X 33.0
+#else
+#define TOOLHEAD_OFFSET_X PLATFORM_TOOLHEAD_OFFSET_X
 #endif
 
 #endif

--- a/firmware/src/MightyBoard/shared/Menu_locales.hh
+++ b/firmware/src/MightyBoard/shared/Menu_locales.hh
@@ -144,43 +144,14 @@ const static PROGMEM prog_uchar CLEAR_MSG[]     =  "                    ";
 
 #endif // ZYYX_3D_PRINTER
 
-#if defined(MODEL_REPLICATOR)
-#if defined(ZYYX_3D_PRINTER)
-const static PROGMEM prog_uchar SPLASH1_MSG[] = "  ZYYX 3D Printer   ";
-#elif defined(AZTEEG_X3)
-const static PROGMEM prog_uchar SPLASH1_MSG[] = "Sailfish Azteeg "
-#ifdef XY_MIN_HOMING
-	"XYmn";
-#else
-    "XYmx";
-#endif
-#elif defined(FF_CREATOR)
-const static PROGMEM prog_uchar SPLASH1_MSG[] = "Sailfish FF Creator ";
-#elif defined(FF_CREATOR_X)
-const static PROGMEM prog_uchar SPLASH1_MSG[] = "Sailfish FF CreatorX";
-#elif defined(WANHAO_DUP4)
-const static PROGMEM prog_uchar SPLASH1_MSG[] = "Wanhao Duplicator 4 ";
-#elif defined(CORE_XY_STEPPER)
-const static PROGMEM prog_uchar SPLASH1_MSG[] = "Sailfish Rep CoreXYs";
-#elif defined(CORE_XY)
-const static PROGMEM prog_uchar SPLASH1_MSG[] = "Sailfish Rep1 CoreXY";
-#elif defined(CORE_XYZ)
-const static PROGMEM prog_uchar SPLASH1_MSG[] = "Sailfish R1 CoreXYZ ";
-#else
-const static PROGMEM prog_uchar SPLASH1_MSG[] = "Sailfish Replicator1";
-#endif
-#elif defined(MODEL_REPLICATOR2)
-#ifdef SINGLE_EXTRUDER
-const static PROGMEM prog_uchar SPLASH1_MSG[] = "Sailfish Replicator2";
-#else
-const static PROGMEM prog_uchar SPLASH1_MSG[] = "  Sailfish Rep 2X   ";
-#endif
-#else
-#warning "*** Compiling without MODEL_x defined ***"
+#if !defined(PLATFORM_SPLASH1_MSG)
+#warning "Building with no PLATFORM_SPLASH1_MSG defined."
 const static PROGMEM prog_uchar SPLASH1_MSG[] = "      Sailfish      ";
+#else
+const static PROGMEM prog_uchar SPLASH1_MSG[] = PLATFORM_SPLASH1_MSG;
 #endif
 
-#if !defined(HEATERS_ON_STEROIDS) || defined(ZYYX_3D_PRINTER) || defined(FF_CREATOR) || defined(FF_CREATOR_X) || defined(WANHAO_DUP4)
+#if !defined(HEATERS_ON_STEROIDS)
 const static PROGMEM prog_uchar SPLASH2_MSG[] = "--- Thing 32084 ----";
 #else
 const static PROGMEM prog_uchar SPLASH2_MSG[] = "-- Heater Special --";

--- a/firmware/src/platforms.py
+++ b/firmware/src/platforms.py
@@ -43,6 +43,24 @@ platforms = {
 #                      (e.g., mighty_one)
 #   defines    -- List of #defines to establish.  Any string prefixed with '-'
 #                 will be removed from the list of #defines to establish.
+#	 PLATFORM_THE_REPLICATOR_STR -- The "Replicator" string
+#        PLATFORM_MACHINE_ID         -- Machine ID
+#        PLATFORM_TOOLHEAD_OFFSET_X  -- X distance between toolheads
+#        PLATFORM_SPLASH1_MSG        -- First line of the splash message
+#                                       *** MAKE SURE THIS IS EXACTLY 20 ***
+#                                       *** CHARACTERS IN LENGTH         ***
+#	 PLATFORM_ENDSTOP_INVERT     -- bitmask for endstop inversion (0bN--BAZYX,
+#                                       N means all endstop inverted)
+#        PLATFORM_HOME_DIRECTION     -- bitmask for home direction (0b---BAZYX),
+#                                       AB max - to never halt on edge in stepper
+#                                       interface.
+#        PLATFORM_AXIS_INVERT        -- bitmask for axis inversion (0b---BAZYX)
+#        PLATFORM_AXIS_OFFSETS       -- distance delta between toolheads and the
+#                                       ideal 'center' of the toolhead system, in
+#                                       steps.
+#        PLATFORM_AXIS_LENGTHS       -- maximum lengths of all axis (X/Y/Z/A/B)
+#        PLATFORM_AXIS_STEPS_PER_MM  -- steps per mm for all axis (X/Y/Z/A/B),
+#                                       all values multiplied by 1,000,000.
 #   squeeze    -- Source files to compile --mcall-prologues so as to save
 #                 code space.
 
@@ -56,7 +74,8 @@ platforms = {
                         'UtilityScripts.cc', 'RGB_LED.cc',
                         'StandardButtonArray.cc',
   '[ os.path.basename(f) for f in glob.glob(\'../../src/MightyBoard/Motherboard/boards/mighty_one/*.cc\') ]' ],
-          'defines' : [ 'HAS_RGB_LED', 'EEPROM_MENU_ENABLE' ]
+          'defines' : [ 'HAS_RGB_LED', 'EEPROM_MENU_ENABLE',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish Replicator1\\\"' ]
           },
 
     'mighty_one-corexy' :
@@ -70,7 +89,8 @@ platforms = {
   '[ os.path.basename(f) for f in glob.glob(\'../../src/MightyBoard/Motherboard/lib_sd/*.c\') ]',
   '[ os.path.basename(f) for f in glob.glob(\'../../src/MightyBoard/Motherboard/boards/mighty_one/*.cc\') ]' ],
           'defines' : [ 'CORE_XY', 'HEATERS_ON_STEROIDS', 'BUILD_STATS',
-                        'COOLING_FAN_PWM', 'HAS_RGB_LED', 'EEPROM_MENU_ENABLE' ]
+                        'COOLING_FAN_PWM', 'HAS_RGB_LED', 'EEPROM_MENU_ENABLE',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish Rep1 CoreXY\\\"' ]
         },
 
     'mighty_one-2560' :
@@ -79,6 +99,7 @@ platforms = {
           'board_directory' : 'mighty_one',
           'defines' : [ 'BUILD_STATS', 'ALTERNATE_UART', 'AUTO_LEVEL',
                         'PSTOP_ZMIN_LEVEL', 'HAS_RGB_LED',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish Replicator1\\\"',
                         'EEPROM_MENU_ENABLE', 'RGB_LED_MENU' ]
         },
 
@@ -89,6 +110,7 @@ platforms = {
           'defines' : [ 'CORE_XY', 'BUILD_STATS', 'ALTERNATE_UART',
                         'HEATERS_ON_STEROIDS', 'AUTO_LEVEL', 'HAS_RGB_LED',
                         'PSTOP_ZMIN_LEVEL', 'COOLING_FAN_PWM',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish Rep1 CoreXY\\\"',
                         'EEPROM_MENU_ENABLE', 'RGB_LED_MENU' ]
         },
 
@@ -99,6 +121,11 @@ platforms = {
           'defines' : [ 'CORE_XY', 'BUILD_STATS', 'ALTERNATE_UART',
                         'HEATERS_ON_STEROIDS', 'AUTO_LEVEL', 'HAS_RGB_LED',
                         'PSTOP_ZMIN_LEVEL', 'COOLING_FAN_PWM',
+                        'PLATFORM_SPLASH1_MSG=\\\" Sailfish Clone R1 \\\"',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"CloneR1\\\"',
+                        'PLATFORM_AXIS_OFFSETS={14444L, 1444L, 8667L, 8667L}',
+                        'PLATFORM_AXIS_LENGTHS={300L, 195L, 210L, 100000L, 100000L}',
+                        'PLATFORM_AXIS_STEPS_PER_MM={88888889, 88888889, 400000000, 96275202, 96275202}',
                         'EEPROM_MENU_ENABLE', 'CLONE_R1', 'RGB_LED_MENU' ]
         },
 
@@ -109,6 +136,7 @@ platforms = {
           'defines' : [ 'CORE_XY', 'BUILD_STATS', 'ALTERNATE_UART',
                         'HAS_RGB_LED', 'HEATERS_ON_STEROIDS', 'AUTO_LEVEL',
                         'MAX31855', 'PSTOP_ZMIN_LEVEL', 'COOLING_FAN_PWM',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish Rep1 CoreXY\\\"',
                         'EEPROM_MENU_ENABLE', 'RGB_LED_MENU' ]
         },
 
@@ -118,6 +146,7 @@ platforms = {
           'board_directory' : 'mighty_one',
           'defines' : [ 'BUILD_STATS', 'ALTERNATE_UART', 'MAX31855',
                         'AUTO_LEVEL', 'PSTOP_ZMIN_LEVEL', 'HAS_RGB_LED',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish Replicator1\\\"',
                         'EEPROM_MENU_ENABLE', 'RGB_LED_MENU' ]
         },
 
@@ -126,6 +155,13 @@ platforms = {
           'programmer' : 'stk500v1',
           'board_directory' : 'mighty_two',
           'defines' : [ 'SINGLE_EXTRUDER', 'BUILD_STATS', 'HAS_RGB_LED',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish Replicator2\\\"',
+                        'PLATFORM_TOOLHEAD_OFFSET_X=35.0',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"Replicator 2\\\"',
+                        'PLATFORM_MACHINE_ID=0xB015',
+                        'PLATFORM_AXIS_OFFSETS={13463L, 13463L, 6643L, 6377L}',
+                        'PLATFORM_AXIS_LENGTHS={285L, 152L, 155L, 100000L, 100000L}',
+                        'PLATFORM_AXIS_STEPS_PER_MM={88573186, 88573186, 400000000, 96275202, 96275202}',
                         'EEPROM_MENU_ENABLE' ],
           'squeeze' : [ 'Menu.cc', 'Interface.cc', 'InterfaceBoard.cc',
                         'LiquidCrystalSerial.cc', 'DigiPots.cc',
@@ -142,6 +178,13 @@ platforms = {
           'programmer' : 'stk500v1',
           'board_directory' : 'mighty_two',
           'defines' : [ 'CORE_XY', 'SINGLE_EXTRUDER', 'BUILD_STATS', 'HAS_RGB_LED',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish Rep2 CoreXY\\\"',
+                        'PLATFORM_TOOLHEAD_OFFSET_X=35.0',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"Replicator 2\\\"',
+                        'PLATFORM_MACHINE_ID=0xB015',
+                        'PLATFORM_AXIS_OFFSETS={13463L, 13463L, 6643L, 6377L}',
+                        'PLATFORM_AXIS_LENGTHS={285L, 152L, 155L, 100000L, 100000L}',
+                        'PLATFORM_AXIS_STEPS_PER_MM={88573186, 88573186, 400000000, 96275202, 96275202}',
                         'EEPROM_MENU_ENABLE' ],
           'squeeze' : [ 'Menu.cc', 'Interface.cc', 'InterfaceBoard.cc',
                         'LiquidCrystalSerial.cc', 'DigiPots.cc',
@@ -158,6 +201,13 @@ platforms = {
           'programmer' : 'stk500v2',
           'board_directory' : 'mighty_two',
           'defines' : [ 'SINGLE_EXTRUDER', 'BUILD_STATS', 'ALTERNATE_UART',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish Replicator2\\\"',
+                        'PLATFORM_TOOLHEAD_OFFSET_X=35.0',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"Replicator 2\\\"',
+                        'PLATFORM_MACHINE_ID=0xB015',
+                        'PLATFORM_AXIS_OFFSETS={13463L, 13463L, 6643L, 6377L}',
+                        'PLATFORM_AXIS_LENGTHS={285L, 152L, 155L, 100000L, 100000L}',
+                        'PLATFORM_AXIS_STEPS_PER_MM={88573186, 88573186, 400000000, 96275202, 96275202}',
                         'AUTO_LEVEL', 'PSTOP_ZMIN_LEVEL', 'HAS_RGB_LED',
                         'EEPROM_MENU_ENABLE', 'RGB_LED_MENU' ]
         },
@@ -173,7 +223,15 @@ platforms = {
                         'Thermistor.cc', 'Thermocouple.cc', 'Heater.cc',
                         'CoolingFan.cc', 'PID.cc',
   '[ os.path.basename(f) for f in glob.glob(\'../../src/MightyBoard/Motherboard/boards/mighty_two/*.cc\') ]' ],
-          'defines' : [ 'BUILD_STATS', 'HAS_RGB_LED', 'EEPROM_MENU_ENABLE' ]
+          'defines' : [ 'BUILD_STATS', 'HAS_RGB_LED',
+                        'PLATFORM_SPLASH1_MSG=\\\"  Sailfish Rep 2X   \\\"',
+                        'PLATFORM_TOOLHEAD_OFFSET_X=35.0',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"Replicator 2X\\\"',
+                        'PLATFORM_MACHINE_ID=0xB017',
+                        'PLATFORM_AXIS_OFFSETS={13463L, 13463L, 6643L, 6377L}',
+                        'PLATFORM_AXIS_LENGHTS={246L, 152L, 155L, 100000L, 100000L}',
+                        'PLATFORM_AXIS_STEPS_PER_MM={88573186, 88573186, 400000000, 96275202, 96275202}',
+                        'EEPROM_MENU_ENABLE' ]
         },
 
     'mighty_twox-2560' :
@@ -182,6 +240,12 @@ platforms = {
           'board_directory' : 'mighty_two',
           'defines' : [ 'BUILD_STATS', 'ALTERNATE_UART', 'AUTO_LEVEL',
                         'PSTOP_ZMIN_LEVEL', 'HAS_RGB_LED',
+                        'PLATFORM_SPLASH1_MSG=\\\"  Sailfish Rep 2X   \\\"',
+                        'PLATFORM_TOOLHEAD_OFFSET_X=35.0',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"Replicator 2X\\\"',
+                        'PLATFORM_MACHINE_ID=0xB017',
+                        'PLATFORM_AXIS_OFFSETS={13463L, 13463L, 6643L, 6377L}',
+                        'PLATFORM_AXIS_STEPS_PER_MM={88573186, 88573186, 400000000, 96275202, 96275202}',
                         'EEPROM_MENU_ENABLE', 'RGB_LED_MENU' ]
         },
 
@@ -193,8 +257,11 @@ platforms = {
                         'LiquidCrystalSerial.cc', 'DigiPots.cc',
                         'Eeprom.cc', 'EepromMap.cc', 'Piezo.cc',
                         'UtilityScripts.cc' ],
-          'defines' :  [ 'FF_CREATOR', 'HEATERS_ON_STEROIDS', 'HAS_RGB_LED',
-                         'EEPROM_MENU_ENABLE' ]
+          'defines' : [ 'FF_CREATOR', 'HEATERS_ON_STEROIDS', 'HAS_RGB_LED',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish FF Creator \\\"',
+                        'PLATFORM_TOOLHEAD_OFFSET_X=34.0',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"FF Creator\\\"',
+                        'EEPROM_MENU_ENABLE' ]
         },
 
     'ff_creator-2560' :
@@ -202,6 +269,9 @@ platforms = {
           'programmer' : 'stk500v2',
           'board_directory' : 'mighty_one',
           'defines' : [ 'FF_CREATOR', 'BUILD_STATS', 'ALTERNATE_UART',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish FF Creator \\\"',
+                        'PLATFORM_TOOLHEAD_OFFSET_X=34.0',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"FF Creator\\\"',
                         'HEATERS_ON_STEROIDS', 'AUTO_LEVEL',
                         'PSTOP_ZMIN_LEVEL', 'HAS_RGB_LED', 'RGB_LED_MENU',
                         'EEPROM_MENU_ENABLE' ]
@@ -212,6 +282,9 @@ platforms = {
           'programmer' : 'stk500v2',
           'board_directory' : 'mighty_one',
           'defines' : [ 'BUILD_STATS', 'ALTERNATE_UART', 'FF_CREATOR_X',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish FF CreatorX\\\"',
+                        'PLATFORM_TOOLHEAD_OFFSET_X=34.0',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"Creator X / Pro\\\"',
                         'HEATERS_ON_STEROIDS', 'AUTO_LEVEL',
                         'PSTOP_ZMIN_LEVEL', 'HAS_RGB_LED', 'RGB_LED_MENU',
                         'EEPROM_MENU_ENABLE' ]
@@ -226,6 +299,9 @@ platforms = {
                         'Eeprom.cc', 'EepromMap.cc', 'Piezo.cc',
                         'UtilityScripts.cc' ],
           'defines' : [ 'WANHAO_DUP4', 'HEATERS_ON_STEROIDS',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish Wanhao Dup4\\\"',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"Wanhao Duplicator\\\"',
+                        'PLATFORM_AXIS_OFFSETS={13763L, 13763L, 6919L, 6919L}',
                         'HAS_RGB_LED', 'EEPROM_MENU_ENABLE' ]
         },
 
@@ -238,6 +314,11 @@ platforms = {
                         'Eeprom.cc', 'EepromMap.cc', 'Piezo.cc',
                         'UtilityScripts.cc' ],
           'defines' : [ 'SINGLE_EXTRUDER', 'ZYYX_3D_PRINTER',
+                        'PLATFORM_SPLASH1_MSG=\\\" Sailfish ZYYX 3DP  \\\"',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"ZYYX 3D Printer\\\"',
+                        'PLATFORM_AXIS_OFFSETS={11957L, 11957L, 10186L, 10186L}',
+                        'PLATFORM_AXIS_LENGTHS={270L, 230L, 195L, 100000L, 100000L}',
+                        'PLATFORM_AXIS_STEPS_PER_MM={88573186, 88573186, 400000000, 96275202, 96275202}',
                         'AUTO_LEVEL', 'AUTO_LEVEL_ZYYX', 'PSTOP_ZMIN_LEVEL' ]
         },
 
@@ -247,6 +328,11 @@ platforms = {
           'board_directory' : 'mighty_one',
           'defines' : [ 'EEPROM_MENU_ENABLE', 'BUILD_STATS', 'SINGLE_EXTRUDER',
                         'ALTERNATE_UART', 'ZYYX_3D_PRINTER',
+                        'PLATFORM_SPLASH1_MSG=\\\" Sailfish ZYYX 3DP  \\\"',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"ZYYX 3D Printer\\\"',
+                        'PLATFORM_AXIS_OFFSETS={11957L, 11957L, 10186L, 10186L}',
+                        'PLATFORM_AXIS_LENGTHS={270L, 230L, 195L, 100000L, 100000L}',
+                        'PLATFORM_AXIS_STEPS_PER_MM={88573186, 88573186, 400000000, 96275202, 96275202}',
                         'HEATERS_ON_STEROIDS', 'AUTO_LEVEL', 'AUTO_LEVEL_ZYYX',
                         'PSTOP_ZMIN_LEVEL', 'ZYYX_LEVEL_SCRIPT' ]
         },
@@ -257,6 +343,11 @@ platforms = {
           'board_directory' : 'mighty_one',
           'defines' : [ 'EEPROM_MENU_ENABLE', 'BUILD_STATS',
                         'ALTERNATE_UART', 'ZYYX_3D_PRINTER',
+                        'PLATFORM_SPLASH1_MSG=\\\" Sailfish ZYYX 3DP  \\\"',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"ZYYX 3D Printer\\\"',
+                        'PLATFORM_AXIS_OFFSETS={11957L, 11957L, 10186L, 10186L}',
+                        'PLATFORM_AXIS_LENGTHS={270L, 230L, 195L, 100000L, 100000L}',
+                        'PLATFORM_AXIS_STEPS_PER_MM={88573186, 88573186, 400000000, 96275202, 96275202}',
                         'HEATERS_ON_STEROIDS', 'AUTO_LEVEL', 'AUTO_LEVEL_ZYYX',
                         'PSTOP_ZMIN_LEVEL', 'ZYYX_LEVEL_SCRIPT' ]
         },
@@ -266,6 +357,9 @@ platforms = {
           'programmer' : 'stk500v2',
           'board_directory' : 'azteeg_x3',
           'defines' : [ 'BUILD_STATS', 'HEATERS_ON_STEROIDS',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish Azteeg XYmx\\\"',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"Azteeg X3\\\"',
+                        'PLATFORM_AXIS_OFFSETS={14309L, 14309L, 7060L, 6778L}',
                         'AUTO_LEVEL', 'PSTOP_ZMIN_LEVEL', 'COOLING_FAN_PWM',
                         'EEPROM_MENU_ENABLE', 'HAS_RGB_LED', 'RGB_LED_MENU' ]
         },
@@ -275,6 +369,9 @@ platforms = {
           'programmer' : 'stk500v2',
           'board_directory' : 'azteeg_x3',
           'defines' : [ 'CORE_XY', 'BUILD_STATS', 'HEATERS_ON_STEROIDS',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish Azteeg XYmx\\\"',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"Azteeg X3\\\"',
+                        'PLATFORM_AXIS_OFFSETS={14309L, 14309L, 7060L, 6778L}',
                         'AUTO_LEVEL', 'PSTOP_ZMIN_LEVEL', 'COOLING_FAN_PWM',
                         'EEPROM_MENU_ENABLE', 'HAS_RGB_LED', 'RGB_LED_MENU' ]
         },
@@ -284,6 +381,9 @@ platforms = {
           'programmer' : 'stk500v2',
           'board_directory' : 'azteeg_x3',
           'defines' : [ 'BUILD_STATS', 'HEATERS_ON_STEROIDS', 'XY_MIN_HOMING',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish Azteeg XYmn\\\"',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"Azteeg X3\\\"',
+                        'PLATFORM_AXIS_OFFSETS={14309L, 14309L, 7060L, 6778L}',
                         'AUTO_LEVEL', 'PSTOP_ZMIN_LEVEL', 'COOLING_FAN_PWM',
                         'EEPROM_MENU_ENABLE', 'HAS_RGB_LED', 'RGB_LED_MENU' ]
         },
@@ -293,6 +393,9 @@ platforms = {
           'programmer' : 'stk500v2',
           'board_directory' : 'azteeg_x3',
           'defines' : [ 'CORE_XY', 'BUILD_STATS', 'HEATERS_ON_STEROIDS',
+                        'PLATFORM_SPLASH1_MSG=\\\"Sailfish Azteeg XYmn\\\"',
+                        'PLATFORM_THE_REPLICATOR_STR=\\\"Azteeg X3\\\"',
+                        'PLATFORM_AXIS_OFFSETS={0L, 0L, 0L, 0L}',
                         'AUTO_LEVEL', 'PSTOP_ZMIN_LEVEL', 'COOLING_FAN_PWM',
                         'EEPROM_MENU_ENABLE', 'HAS_RGB_LED', 'RGB_LED_MENU',
                         'XY_MIN_HOMING' ]


### PR DESCRIPTION
This should make adapting new machines easier, since machine dependent values could be set in platforms.py (and ~/.sailfish_platforms.py), respectively.

currently worked:
- THE_REPLICATOR_STR
- MACHINE_ID
- TOOLHEAD_OFFSET_X
- ENDSTOP_INVERT (EEPROM default)
- HOME_DIERCTION (EEPROM default)
- AXIS_INVERT (EEPROM default)
- AXIS_OFFSETS (EEPROM default)
- AXIS_LENGTHS (EEPROM default)
- AXIS_STEPS_PER_MM (EEPROM default)

for the "EEPROM defaults", means that it sets the values to these ones during a factory reset, but can still be configured with ReplicatorG.

I carefully verified that the build remains identical before and after the patch (eg, all values above the same), but this is not garenteed......
my bot is FlashForge Creator X (2560), so people with other bots should pay attention to the values in order to *NOT* damaging their bots.