### PR TITLE
toJetty: script tweaks

### DIFF
--- a/firmware/build.sh
+++ b/firmware/build.sh
@@ -18,6 +18,7 @@ else
 fi
 
 VER=`awk -F'.' '{printf("%d.%d.%d",$1,$2,$3); exit}' $FWDIR/current_version.txt`
+SCONS="scons -j${JOBS:-4}"
 
 for BUILD in `python src/platforms.py`
 do
@@ -26,7 +27,7 @@ do
 
     for LOCALE in "en" "de" "fr"
     do
-        scons platform=$BUILD locale=$LOCALE
+        $SCONS platform=$BUILD locale=$LOCALE
         ./checksize.sh $BUILD .$LOCALE
         if [ $? -ne 0 ]; then
 	        exit 1
@@ -50,7 +51,7 @@ do
 
     for LOCALE in "en" "de" "fr"
     do
-        scons platform=$BUILD broken_sd=1 locale=$LOCALE
+        $SCONS platform=$BUILD broken_sd=1 locale=$LOCALE
         ./checksize.sh $BUILD b.$LOCALE
         if [ $? -ne 0 ]; then
 	        exit 1

--- a/firmware/checksize.sh
+++ b/firmware/checksize.sh
@@ -13,15 +13,16 @@ else
     MAXSIZE=131072
 fi
 
-TMPFILE=/tmp/mightyboard-awk-prog.tmp
-echo "{ if ( \$1 != \"text\" ) print \$1+\$2+$BOOTLOADER }" > $TMPFILE
-SIZE=`avr-size build/$BUILD/*$LOCALE.elf | awk -f $TMPFILE`
-rm $TMPFILE
+for FILE in build/${BUILD}/*${LOCALE}.elf
+do
+	SIZE=$(avr-size ${FILE} | awk -e "{ if ( \$1 != \"text\" ) print \$1+\$2+${BOOTLOADER} }")
 
-if [ $SIZE -gt $MAXSIZE ] ; then
-    echo "**** size($BUILD)=$SIZE which exceeds $MAXSIZE bytes ****"
-    exit 1
-fi
+	if [ $SIZE -gt $MAXSIZE ]
+	then
+	    echo "**** size($BUILD)=$SIZE which exceeds $MAXSIZE bytes ****"
+	    exit 1
+	fi
 
-echo "*** $BUILD $LOCALE is $SIZE bytes"
+	echo "*** $FILE is $SIZE / $MAXSIZE bytes"
+done
 exit 0

--- a/firmware/src/MightyBoard/shared/Menu_locales.hh
+++ b/firmware/src/MightyBoard/shared/Menu_locales.hh
@@ -163,7 +163,7 @@ const static PROGMEM prog_uchar SPLASH3_MSG[] = "ATmega 2560 " DATE_STR;
 const static PROGMEM prog_uchar SPLASH3_MSG[] = "ATmega 1280 " DATE_STR;
 #endif
 
-const static PROGMEM prog_uchar SPLASH4_MSG[] = "Sailfish v" VERSION_STR " r" SVN_VERSION_STR;
+const static PROGMEM prog_uchar SPLASH4_MSG[] = "Sailfish v" VERSION_STR " r" VCS_VERSION_STR;
 
 #include "locale.hh"
 

--- a/firmware/src/SConscript.mightyboard
+++ b/firmware/src/SConscript.mightyboard
@@ -111,12 +111,14 @@ if broken_sd == '1':
 
 # Get the svn version number and use the last part
 if os.path.exists('../../../../../../.svn'):
-   svn_version = os.popen('svnversion ../../../../../..').read()[:-1]
-   svn_version = svn_version.split(':')[-1]
+   vcs_version = os.popen('svnversion ../../../../../..').read()[:-1]
+   vcs_version = vcs_version.split(':')[-1]
 elif os.path.exists('../../svn-version'):
-   svn_version = open('../../svn-version', 'r').read().strip()
+   vcs_version = open('../../svn-version', 'r').read().strip()
+elif os.path.exists('../../../.git'):
+   vcs_version = '\\\"`git log --pretty=format:\'%h\' --abbrev=5 -n 1`\\\"'
 else:
-   svn_version = "1234"
+   vcs_version = "1234"
 
 def parse_version(v):
     if not v:
@@ -148,8 +150,8 @@ flags=[
 	'-DVERSION='+str(int(version[0])*100 + int(version[1])),
 	'-DSTREAM_VERSION='+str(int(version[3])*100 + int(version[4])),
   	'-DVERSION_INTERNAL='+str(int(version[2])),
-        '-DSVN_VERSION='+str(svn_version),
-	'-DSVN_VERSION_STR=\'"'+str(svn_version).zfill(5)+'"\'',
+        '-DVCS_VERSION='+str(vcs_version),
+	'-DVCS_VERSION_STR='+str(vcs_version).zfill(5),
 	'-DVERSION_STR=\'"'+version_str+'"\'',
 	'-DDATE_STR=\'"'+datetime.now().strftime('%y/%m/%d')+'"\'',
 	'-g',


### PR DESCRIPTION
some scripts tuning...

1. i just happened to get annoyed by the "Sailfish v7.8 r01234" every boot...
2. checksize.sh doesn't work when there is more than one .elf file in the build directory.
3. why build with -j1 when you just happen to have 8 cpu cores?