### PR TITLE
check endstop during print for CoreXY

### DIFF
--- a/firmware/src/MightyBoard/Motherboard/StepperAccel.cc
+++ b/firmware/src/MightyBoard/Motherboard/StepperAccel.cc
@@ -439,7 +439,44 @@ FORCE_INLINE void setup_next_block() {
 	//debug_onscreen1 = DEBUG_TIMER_TCTIMER_CYCLES;
 }
 
+#if defined(CORE_XY) || defined(CORE_XY_STEPPER)
+/**
+ * @return true if we can step the XY stepper, false otherwise.
+ */
+bool stepperAxis_check_endstop_corexy() {
+#define DDA(axis) (stepperAxis[axis].dda)
+	bool xmax = stepperAxisIsAtMaximumCoreXY(X_AXIS);
+	bool xmin = stepperAxisIsAtMinimumCoreXY(X_AXIS);
+	bool ymax = stepperAxisIsAtMaximumCoreXY(Y_AXIS);
+	bool ymin = stepperAxisIsAtMinimumCoreXY(Y_AXIS);
 
+	// if no endstop is triggered, avoid the fancy mathematics.
+	if (!(xmax || ymax || xmin || ymin))
+		return true;
+
+	// working with dda, should be critical.
+	CRITICAL_SECTION_START;
+	int32_t asteps = (DDA(X_AXIS).steps - DDA(X_AXIS).steps_completed) * DDA(X_AXIS).direction;
+	int32_t bsteps = (DDA(Y_AXIS).steps - DDA(Y_AXIS).steps_completed) * DDA(Y_AXIS).direction;
+	CRITICAL_SECTION_END;
+
+	int32_t xsteps = asteps + bsteps;
+	int32_t ysteps = asteps - bsteps;
+
+	if ( (xmax && xsteps > 0) || (xmin && xsteps < 0) ) {
+		axis_homing[X_AXIS] = false;
+		return false;
+	}
+	if ( (ymax && ysteps > 0) || (ymin && ysteps < 0) ) {
+		axis_homing[Y_AXIS] = false;
+		return false;
+	}
+
+	// we're not moving against the endstop
+	return true;
+#undef DDA
+}
+#endif
 
 // "The Stepper Driver Interrupt" - This timer interrupt is the workhorse.
 // It pops blocks from the block_buffer and executes them by pulsing the stepper pins appropriately.
@@ -454,9 +491,17 @@ bool st_interrupt() {
 			oversampledCount ++;
 
 			if ( oversampledCount < (1 << OVERSAMPLED_DDA) ) {
+#if defined(CORE_XY) || defined(CORE_XY_STEPPER)
+				stepperAxis_check_endstop_corexy();
+#endif
 				//Step the dda for each axis
-				stepperAxis_dda_step(X_AXIS);
-				stepperAxis_dda_step(Y_AXIS);
+#if defined(CORE_XY) || defined(CORE_XY_STEPPER)
+				if (stepperAxis_check_endstop_corexy())
+#endif
+				{
+					stepperAxis_dda_step(X_AXIS);
+					stepperAxis_dda_step(Y_AXIS);
+				}
 				stepperAxis_dda_step(Z_AXIS);
 				stepperAxis_dda_step(A_AXIS);
 				stepperAxis_dda_step(B_AXIS);
@@ -529,8 +574,13 @@ bool st_interrupt() {
 			#endif
 
 			//Step the dda for each axis
-			stepperAxis_dda_step(X_AXIS);
-			stepperAxis_dda_step(Y_AXIS);
+#if defined(CORE_XY) || defined(CORE_XY_STEPPER)
+			if (stepperAxis_check_endstop_corexy())
+#endif
+			{
+				stepperAxis_dda_step(X_AXIS);
+				stepperAxis_dda_step(Y_AXIS);
+			}
 			stepperAxis_dda_step(Z_AXIS);
 			stepperAxis_dda_step(A_AXIS);
 			stepperAxis_dda_step(B_AXIS);


### PR DESCRIPTION
the X/Y endstops were only used for homing. it's probably okay if
you always make sure that your GCode doesn't move the cartridge
out of the working area, but those endstops are there for a reason.

so, better safe than sorry, just check endstop status before each
step (just like what we did for the normal cartesian kinematics
systems), and make sure we CAN move the cartridge before we actually
DO move the cartridge.

this still ruins your print, but it saves your bot.

the performance should remain pretty much the same, since we
only do those fancy mathematics whenever one of the endstop is
trigger.