### PR TITLE
Rebased sd improvements

### DIFF
--- a/firmware/src/MightyBoard/Motherboard/lib_sd/ChangeLog
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/ChangeLog
@@ -2,6 +2,10 @@
 	* Added CRC support
 	* Added sd_errno and fat_errno so that information about errors can percolate upstack
 	
+2012-06-12 sd-reader
+	* fix capacity readout from csd register depending on format version
+	* fix gcc strict-aliasing warnings (also somewhat enlarges code size)
+
 2011-04-23 sd-reader
 	* fix FAT access for cluster numbers beyond 2^15 (for FAT16) and 2^30 (for FAT32) (thanks to Darwin Engwer for testing)
 	* correctly return disk-full condition from fat_write_file() on certain conditions

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/ChangeLog
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/ChangeLog
@@ -2,6 +2,13 @@
 	* Added CRC support
 	* Added sd_errno and fat_errno so that information about errors can percolate upstack
 	
+2011-02-05 sd-reader
+	* implement renaming a file or directory
+	* rewrite byteorder handling to fix unaligned memory accesses on 32-bit and probably 16-bit architectures
+	* make fat_create_file() not return failure if the file already exists
+	* make the "cat" output respect the count of bytes actually read
+	* document how to use fat_seek_file() for retrieving the file position
+
 2010-10-10 sd-reader
 	* Fix equal file names when reading two successive 8.3 directory entries.
 	* Fix calculation of cluster positions beyond 4GB (32 bit integer overflow).

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/ChangeLog
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/ChangeLog
@@ -2,6 +2,12 @@
 	* Added CRC support
 	* Added sd_errno and fat_errno so that information about errors can percolate upstack
 	
+2011-04-23 sd-reader
+	* fix FAT access for cluster numbers beyond 2^15 (for FAT16) and 2^30 (for FAT32) (thanks to Darwin Engwer for testing)
+	* correctly return disk-full condition from fat_write_file() on certain conditions
+	* use byteorder memory access functions for fat_fs_get_free()
+	* be more specific on the return value of fat_write_file()
+
 2011-02-05 sd-reader
 	* implement renaming a file or directory
 	* rewrite byteorder handling to fix unaligned memory accesses on 32-bit and probably 16-bit architectures

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/README.txt
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/README.txt
@@ -3,7 +3,12 @@ Roland Riegel's excellent SD/MMC card library.  You can find
 the latest version of the code here:
 http://www.roland-riegel.de/sd-reader/doc/
 
-This particular version is from the 2010-01-10 release.
+The Sailfish firmware initially started by forking the 2010-01-10 release.
+Some changes (including the larger one below) were made over time.
+In 2017, some cleanup and rebasing was performed by Ryan Pavlik to
+merge newer upstream versions into a combined tree with Sailfish changes,
+so the current code here corresponds to the 2012-06-12 release merged with
+the Sailfish-originated changes.
 
 Dan Newman <dan.newman@mtbaldy.us> added CRC support and error return
   handling, February 2013.

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/byteordering.c
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/byteordering.c
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2012 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2
@@ -53,8 +53,6 @@ uint32_t swap32(uint32_t i)
 
 #endif
 
-#if DOXYGEN || !__AVR__
-
 /**
  * Reads a 16-bit integer from memory in little-endian byte order.
  *
@@ -106,8 +104,6 @@ void write32(uint8_t* p, uint32_t i)
     p[1] = (uint8_t) ((i & 0x0000ff00) >>  8);
     p[0] = (uint8_t) ((i & 0x000000ff) >>  0);
 }
-
-#endif
 
 /**
  * @}

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/byteordering.c
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/byteordering.c
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2010 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2
@@ -25,36 +25,88 @@
  * \author Roland Riegel
  */
 
-#if DOXYGEN || !(LITTLE_ENDIAN || __AVR__)
+#if DOXYGEN || SWAP_NEEDED
+
 /**
- * Converts a 16-bit integer to little-endian byte order.
+ * \internal
+ * Swaps the bytes of a 16-bit integer.
  *
- * Use this function on variable values instead of the
- * macro HTOL16(). This saves code size.
- *
- * \param[in] h A 16-bit integer in host byte order.
- * \returns The given 16-bit integer converted to little-endian byte order.
+ * \param[in] i A 16-bit integer which to swap.
+ * \returns The swapped 16-bit integer.
  */
-uint16_t htol16(uint16_t h)
+uint16_t swap16(uint16_t i)
 {
-    return HTOL16(h);
+    return SWAP16(i);
 }
+
+/**
+ * \internal
+ * Swaps the bytes of a 32-bit integer.
+ *
+ * \param[in] i A 32-bit integer which to swap.
+ * \returns The swapped 32-bit integer.
+ */
+uint32_t swap32(uint32_t i)
+{
+    return SWAP32(i);
+}
+
 #endif
 
-#if DOXYGEN || !(LITTLE_ENDIAN || __AVR__)
+#if DOXYGEN || !__AVR__
+
 /**
- * Converts a 32-bit integer to little-endian byte order.
+ * Reads a 16-bit integer from memory in little-endian byte order.
  *
- * Use this function on variable values instead of the
- * macro HTOL32(). This saves code size.
- *
- * \param[in] h A 32-bit integer in host byte order.
- * \returns The given 32-bit integer converted to little-endian byte order.
+ * \param[in] p Pointer from where to read the integer.
+ * \returns The 16-bit integer read from memory.
  */
-uint32_t htol32(uint32_t h)
+uint16_t read16(const uint8_t* p)
 {
-    return HTOL32(h);
+    return (((uint16_t) p[1]) << 8) |
+           (((uint16_t) p[0]) << 0);
 }
+
+/**
+ * Reads a 32-bit integer from memory in little-endian byte order.
+ *
+ * \param[in] p Pointer from where to read the integer.
+ * \returns The 32-bit integer read from memory.
+ */
+uint32_t read32(const uint8_t* p)
+{
+    return (((uint32_t) p[3]) << 24) |
+           (((uint32_t) p[2]) << 16) |
+           (((uint32_t) p[1]) <<  8) |
+           (((uint32_t) p[0]) <<  0);
+}
+
+/**
+ * Writes a 16-bit integer into memory in little-endian byte order.
+ *
+ * \param[in] p Pointer where to write the integer to.
+ * \param[in] i The 16-bit integer to write.
+ */
+void write16(uint8_t* p, uint16_t i)
+{
+    p[1] = (uint8_t) ((i & 0xff00) >> 8);
+    p[0] = (uint8_t) ((i & 0x00ff) >> 0);
+}
+
+/**
+ * Writes a 32-bit integer into memory in little-endian byte order.
+ *
+ * \param[in] p Pointer where to write the integer to.
+ * \param[in] i The 32-bit integer to write.
+ */
+void write32(uint8_t* p, uint32_t i)
+{
+    p[3] = (uint8_t) ((i & 0xff000000) >> 24);
+    p[2] = (uint8_t) ((i & 0x00ff0000) >> 16);
+    p[1] = (uint8_t) ((i & 0x0000ff00) >>  8);
+    p[0] = (uint8_t) ((i & 0x000000ff) >>  0);
+}
+
 #endif
 
 /**

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/byteordering.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/byteordering.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2012 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2
@@ -150,22 +150,12 @@ uint16_t ltoh16(uint16_t l);
  */
 uint32_t ltoh32(uint32_t l);
 
-uint16_t read16(const uint8_t* p);
-uint32_t read32(const uint8_t* p);
-void write16(uint8_t* p, uint16_t i);
-void write32(uint8_t* p, uint32_t i);
-
 #elif SWAP_NEEDED
 
 #define htol16(h) swap16(h)
 #define htol32(h) swap32(h)
 #define ltoh16(l) swap16(l)
 #define ltoh32(l) swap32(l)
-
-uint16_t read16(const uint8_t* p);
-uint32_t read32(const uint8_t* p);
-void write16(uint8_t* p, uint16_t i);
-void write32(uint8_t* p, uint32_t i);
 
 #else
 
@@ -174,19 +164,12 @@ void write32(uint8_t* p, uint32_t i);
 #define ltoh16(l) (l)
 #define ltoh32(l) (l)
 
-#if __AVR__
-#define read16(p) (*(const uint16_t*) (p))
-#define read32(p) (*(const uint32_t*) (p))
-#define write16(p, i) { *((uint16_t*) (p)) = i; }
-#define write32(p, i) { *((uint32_t*) (p)) = i; }
-#else
+#endif
+
 uint16_t read16(const uint8_t* p);
 uint32_t read32(const uint8_t* p);
 void write16(uint8_t* p, uint16_t i);
 void write32(uint8_t* p, uint32_t i);
-#endif
-
-#endif
 
 /**
  * @}

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/byteordering.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/byteordering.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2010 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2
@@ -30,10 +30,27 @@ extern "C"
  * \author Roland Riegel
  */
 
+#define SWAP16(val) ((((uint16_t) (val)) << 8) | \
+                     (((uint16_t) (val)) >> 8)   \
+                    )
+#define SWAP32(val) (((((uint32_t) (val)) & 0x000000ff) << 24) | \
+                     ((((uint32_t) (val)) & 0x0000ff00) <<  8) | \
+                     ((((uint32_t) (val)) & 0x00ff0000) >>  8) | \
+                     ((((uint32_t) (val)) & 0xff000000) >> 24)   \
+                    )
+
+#if LITTLE_ENDIAN || __AVR__
+#define SWAP_NEEDED 0
+#elif BIG_ENDIAN
+#define SWAP_NEEDED 1
+#else
+#error "Endianess undefined! Please define LITTLE_ENDIAN=1 or BIG_ENDIAN=1."
+#endif
+
 /**
  * \def HTOL16(val)
  *
- * Converts a 16-bit integer to little-endian byte order.
+ * Converts a 16-bit integer from host byte order to little-endian byte order.
  *
  * Use this macro for compile time constants only. For variable values
  * use the function htol16() instead. This saves code size.
@@ -44,7 +61,7 @@ extern "C"
 /**
  * \def HTOL32(val)
  *
- * Converts a 32-bit integer to little-endian byte order.
+ * Converts a 32-bit integer from host byte order to little-endian byte order.
  *
  * Use this macro for compile time constants only. For variable values
  * use the function htol32() instead. This saves code size.
@@ -52,28 +69,10 @@ extern "C"
  * \param[in] val A 32-bit integer in host byte order.
  * \returns The given 32-bit integer converted to little-endian byte order.
  */
-
-#if DOXYGEN || LITTLE_ENDIAN || __AVR__
-#define HTOL16(val) (val)
-#define HTOL32(val) (val)
-#elif BIG_ENDIAN
-#define HTOL16(val) ((((uint16_t) (val)) << 8) | \
-                     (((uint16_t) (val)) >> 8)   \
-                    )
-#define HTOL32(val) (((((uint32_t) (val)) & 0x000000ff) << 24) | \
-                     ((((uint32_t) (val)) & 0x0000ff00) <<  8) | \
-                     ((((uint32_t) (val)) & 0x00ff0000) >>  8) | \
-                     ((((uint32_t) (val)) & 0xff000000) >> 24)   \
-                    )
-#else
-#error "Endianess undefined! Please define LITTLE_ENDIAN=1 or BIG_ENDIAN=1."
-#endif
-
-uint16_t htol16(uint16_t h);
-uint32_t htol32(uint32_t h);
-
 /**
- * Converts a 16-bit integer to host byte order.
+ * \def LTOH16(val)
+ *
+ * Converts a 16-bit integer from little-endian byte order to host byte order.
  *
  * Use this macro for compile time constants only. For variable values
  * use the function ltoh16() instead. This saves code size.
@@ -81,10 +80,10 @@ uint32_t htol32(uint32_t h);
  * \param[in] val A 16-bit integer in little-endian byte order.
  * \returns The given 16-bit integer converted to host byte order.
  */
-#define LTOH16(val) HTOL16(val)
-
 /**
- * Converts a 32-bit integer to host byte order.
+ * \def LTOH32(val)
+ *
+ * Converts a 32-bit integer from little-endian byte order to host byte order.
  *
  * Use this macro for compile time constants only. For variable values
  * use the function ltoh32() instead. This saves code size.
@@ -92,10 +91,45 @@ uint32_t htol32(uint32_t h);
  * \param[in] val A 32-bit integer in little-endian byte order.
  * \returns The given 32-bit integer converted to host byte order.
  */
-#define LTOH32(val) HTOL32(val)
+
+#if SWAP_NEEDED
+#define HTOL16(val) SWAP16(val)
+#define HTOL32(val) SWAP32(val)
+#define LTOH16(val) SWAP16(val)
+#define LTOH32(val) SWAP32(val)
+#else
+#define HTOL16(val) (val)
+#define HTOL32(val) (val)
+#define LTOH16(val) (val)
+#define LTOH32(val) (val)
+#endif
+
+#if DOXYGEN
 
 /**
- * Converts a 16-bit integer to host byte order.
+ * Converts a 16-bit integer from host byte order to little-endian byte order.
+ *
+ * Use this function on variable values instead of the
+ * macro HTOL16(). This saves code size.
+ *
+ * \param[in] h A 16-bit integer in host byte order.
+ * \returns The given 16-bit integer converted to little-endian byte order.
+ */
+uint16_t htol16(uint16_t h);
+
+/**
+ * Converts a 32-bit integer from host byte order to little-endian byte order.
+ *
+ * Use this function on variable values instead of the
+ * macro HTOL32(). This saves code size.
+ *
+ * \param[in] h A 32-bit integer in host byte order.
+ * \returns The given 32-bit integer converted to little-endian byte order.
+ */
+uint32_t htol32(uint32_t h);
+
+/**
+ * Converts a 16-bit integer from little-endian byte order to host byte order.
  *
  * Use this function on variable values instead of the
  * macro LTOH16(). This saves code size.
@@ -103,14 +137,10 @@ uint32_t htol32(uint32_t h);
  * \param[in] l A 16-bit integer in little-endian byte order.
  * \returns The given 16-bit integer converted to host byte order.
  */
-#if DOXYGEN
 uint16_t ltoh16(uint16_t l);
-#else
-#define ltoh16(l) htol16(l)
-#endif
 
 /**
- * Converts a 32-bit integer to host byte order.
+ * Converts a 32-bit integer from little-endian byte order to host byte order.
  *
  * Use this function on variable values instead of the
  * macro LTOH32(). This saves code size.
@@ -118,22 +148,53 @@ uint16_t ltoh16(uint16_t l);
  * \param[in] l A 32-bit integer in little-endian byte order.
  * \returns The given 32-bit integer converted to host byte order.
  */
-#if DOXYGEN
 uint32_t ltoh32(uint32_t l);
+
+uint16_t read16(const uint8_t* p);
+uint32_t read32(const uint8_t* p);
+void write16(uint8_t* p, uint16_t i);
+void write32(uint8_t* p, uint32_t i);
+
+#elif SWAP_NEEDED
+
+#define htol16(h) swap16(h)
+#define htol32(h) swap32(h)
+#define ltoh16(l) swap16(l)
+#define ltoh32(l) swap32(l)
+
+uint16_t read16(const uint8_t* p);
+uint32_t read32(const uint8_t* p);
+void write16(uint8_t* p, uint16_t i);
+void write32(uint8_t* p, uint32_t i);
+
 #else
-#define ltoh32(l) htol32(l)
+
+#define htol16(h) (h)
+#define htol32(h) (h)
+#define ltoh16(l) (l)
+#define ltoh32(l) (l)
+
+#if __AVR__
+#define read16(p) (*(const uint16_t*) (p))
+#define read32(p) (*(const uint32_t*) (p))
+#define write16(p, i) { *((uint16_t*) (p)) = i; }
+#define write32(p, i) { *((uint32_t*) (p)) = i; }
+#else
+uint16_t read16(const uint8_t* p);
+uint32_t read32(const uint8_t* p);
+void write16(uint8_t* p, uint16_t i);
+void write32(uint8_t* p, uint32_t i);
+#endif
+
 #endif
 
 /**
  * @}
  */
 
-#if LITTLE_ENDIAN || __AVR__
-#define htol16(h) (h)
-#define htol32(h) (h)
-#else
-uint16_t htol16(uint16_t h);
-uint32_t htol32(uint32_t h);
+#if SWAP_NEEDED
+uint16_t swap16(uint16_t i);
+uint32_t swap32(uint32_t i);
 #endif
 
 #ifdef __cplusplus

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/fat.c
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/fat.c
@@ -1,6 +1,6 @@
 
 /* 
- * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2012 by Roland Riegel <feedback@roland-riegel.de>
  * Modifications Copyright (c) 2013 by Dan Newman <dan.newman@mtbaldy.us>
  *
  * This file is free software; you can redistribute it and/or modify

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/fat.c
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/fat.c
@@ -1178,7 +1178,7 @@ intptr_t fat_read_file(struct fat_file_struct* fd, uint8_t* buffer, uintptr_t bu
  * \param[in] fd The file handle of the file to which to write.
  * \param[in] buffer The buffer from which to read the data to be written.
  * \param[in] buffer_len The amount of data to write.
- * \returns The number of bytes written, 0 on disk full, or -1 on failure.
+ * \returns The number of bytes written (0 or something less than \c buffer_len on disk full) or -1 on failure.
  * \see fat_read_file
  */
 intptr_t fat_write_file(struct fat_file_struct* fd, const uint8_t* buffer, uintptr_t buffer_len)
@@ -2640,7 +2640,7 @@ uint8_t fat_get_fs_free_16_callback(uint8_t* buffer, offset_t offset, void* p)
 
     for(uintptr_t i = 0; i < buffer_size; i += 2, buffer += 2)
     {
-        uint16_t cluster = *((uint16_t*) &buffer[0]);
+        uint16_t cluster = read16(buffer);
         if(cluster == HTOL16(FAT16_CLUSTER_FREE))
             ++(count_arg->cluster_count);
     }
@@ -2662,7 +2662,7 @@ uint8_t fat_get_fs_free_32_callback(uint8_t* buffer, offset_t offset, void* p)
 
     for(uintptr_t i = 0; i < buffer_size; i += 4, buffer += 4)
     {
-        uint32_t cluster = *((uint32_t*) &buffer[0]);
+        uint32_t cluster = read32(buffer);
         if(cluster == HTOL32(FAT32_CLUSTER_FREE))
             ++(count_arg->cluster_count);
     }

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/fat.c
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/fat.c
@@ -252,8 +252,8 @@ struct fat_fs_struct* fat_open(struct partition_struct* partition)
 #endif
       )
     {
-	fat_errno = FAT_ERR_EINVAL;
-	    return 0;
+        fat_errno = FAT_ERR_EINVAL;
+        return 0;
     }
     fat_errno = 0;
 
@@ -261,7 +261,7 @@ struct fat_fs_struct* fat_open(struct partition_struct* partition)
     struct fat_fs_struct* fs = malloc(sizeof(*fs));
     if(!fs)
     {
-	fat_errno = FAT_ERR_EINVAL;
+        fat_errno = FAT_ERR_EINVAL;
         return 0;
     }
 #else
@@ -276,7 +276,7 @@ struct fat_fs_struct* fat_open(struct partition_struct* partition)
     }
     if(i >= FAT_FS_COUNT)
     {
-	fat_errno = FAT_ERR_TOOMANYOPENFILES;
+        fat_errno = FAT_ERR_TOOMANYOPENFILES;
         return 0;
     }
 #endif
@@ -344,8 +344,8 @@ uint8_t fat_read_header(struct fat_fs_struct* fs)
     offset_t partition_offset = (offset_t) partition->offset * 512;
     if(!partition->device_read(partition_offset + 0x0b, buffer, sizeof(buffer)))
     {
-	fat_errno = sd_errno;
-	return 0;
+        fat_errno = sd_errno;
+        return 0;
     }
 
 #pragma GCC diagnostic push
@@ -370,11 +370,11 @@ uint8_t fat_read_header(struct fat_fs_struct* fs)
     if(sector_count == 0)
     {
         if(sector_count_16 == 0)
-	{
+        {
             /* illegal volume size */
-	    fat_errno = FAT_ERR_BADSECTORCOUNT;
+            fat_errno = FAT_ERR_BADSECTORCOUNT;
             return 0;
-	}
+        }
         else
             sector_count = sector_count_16;
     }
@@ -384,14 +384,14 @@ uint8_t fat_read_header(struct fat_fs_struct* fs)
     else if(sectors_per_fat32 == 0)
     {
         /* this is neither FAT16 nor FAT32 */
-	fat_errno = FAT_ERR_UNKNOWNFILESYS;
-	return 0;
+        fat_errno = FAT_ERR_UNKNOWNFILESYS;
+        return 0;
     }
 #else
     if(sectors_per_fat == 0)
     {
         /* this is not a FAT16 */
-	fat_errno = FAT_ERR_BADSECTORSPERFAT;
+        fat_errno = FAT_ERR_BADSECTORSPERFAT;
         return 0;
     }
 #endif
@@ -479,7 +479,7 @@ cluster_t fat_get_next_cluster(const struct fat_fs_struct* fs, cluster_t cluster
 {
     if(!fs || cluster_num < 2)
     {
-	fat_errno = FAT_ERR_EINVAL;
+        fat_errno = FAT_ERR_EINVAL;
         return 0;
     }
 
@@ -489,10 +489,10 @@ cluster_t fat_get_next_cluster(const struct fat_fs_struct* fs, cluster_t cluster
         /* read appropriate fat entry */
         uint32_t fat_entry;
         if(!fs->partition->device_read(fs->header.fat_offset + (offset_t) cluster_num * sizeof(fat_entry), (uint8_t*) &fat_entry, sizeof(fat_entry)))
-	{
-	    fat_errno = sd_errno;
+        {
+            fat_errno = sd_errno;
             return 0;
-	}
+        }
 
         /* determine next cluster from fat */
         cluster_num = ltoh32(fat_entry);
@@ -501,10 +501,10 @@ cluster_t fat_get_next_cluster(const struct fat_fs_struct* fs, cluster_t cluster
            cluster_num == FAT32_CLUSTER_BAD ||
            (cluster_num >= FAT32_CLUSTER_RESERVED_MIN && cluster_num <= FAT32_CLUSTER_RESERVED_MAX) ||
            (cluster_num >= FAT32_CLUSTER_LAST_MIN && cluster_num <= FAT32_CLUSTER_LAST_MAX))
-	{
-	    fat_errno = FAT_ERR_BAD;
+        {
+            fat_errno = FAT_ERR_BAD;
             return 0;
-	}
+        }
     }
     else
 #endif
@@ -512,10 +512,10 @@ cluster_t fat_get_next_cluster(const struct fat_fs_struct* fs, cluster_t cluster
         /* read appropriate fat entry */
         uint16_t fat_entry;
         if(!fs->partition->device_read(fs->header.fat_offset + (offset_t) cluster_num * sizeof(fat_entry), (uint8_t*) &fat_entry, sizeof(fat_entry)))
-	{
-	    fat_errno = sd_errno;
+        {
+            fat_errno = sd_errno;
             return 0;
-	}
+        }
 
         /* determine next cluster from fat */
         cluster_num = ltoh16(fat_entry);
@@ -524,10 +524,10 @@ cluster_t fat_get_next_cluster(const struct fat_fs_struct* fs, cluster_t cluster
            cluster_num == FAT16_CLUSTER_BAD ||
            (cluster_num >= FAT16_CLUSTER_RESERVED_MIN && cluster_num <= FAT16_CLUSTER_RESERVED_MAX) ||
            (cluster_num >= FAT16_CLUSTER_LAST_MIN && cluster_num <= FAT16_CLUSTER_LAST_MAX))
-	{
-	    fat_errno = FAT_ERR_BAD;
+        {
+            fat_errno = FAT_ERR_BAD;
             return 0;
-	}
+        }
     }
 
     return cluster_num;
@@ -549,8 +549,8 @@ cluster_t fat_append_clusters(struct fat_fs_struct* fs, cluster_t cluster_num, c
 {
     if(!fs)
     {
-	fat_errno = FAT_ERR_EINVAL;
-	return 0;
+        fat_errno = FAT_ERR_EINVAL;
+        return 0;
     }
 
     device_read_t device_read = fs->partition->device_read;
@@ -581,19 +581,19 @@ cluster_t fat_append_clusters(struct fat_fs_struct* fs, cluster_t cluster_num, c
         if(is_fat32)
         {
             if(!device_read(fat_offset + (offset_t) cluster_current * sizeof(fat_entry32), (uint8_t*) &fat_entry32, sizeof(fat_entry32)))
-	    {
-		fat_errno = sd_errno;
+            {
+                fat_errno = sd_errno;
                 return 0;
-	    }
+            }
         }
         else
 #endif
         {
             if(!device_read(fat_offset + (offset_t) cluster_current * sizeof(fat_entry16), (uint8_t*) &fat_entry16, sizeof(fat_entry16)))
-	    {
-		fat_errno = sd_errno;
+            {
+                fat_errno = sd_errno;
                 return 0;
-	    }
+            }
         }
 
 #if FAT_FAT32_SUPPORT
@@ -725,10 +725,10 @@ uint8_t fat_free_clusters(struct fat_fs_struct* fs, cluster_t cluster_num)
         while(cluster_num)
         {
             if(!fs->partition->device_read(fat_offset + (offset_t) cluster_num * sizeof(fat_entry), (uint8_t*) &fat_entry, sizeof(fat_entry)))
-	    {
-		fat_errno = sd_errno;
+            {
+                fat_errno = sd_errno;
                 return 0;
-	    }
+            }
 
             /* get next cluster of current cluster before freeing current cluster */
             uint32_t cluster_num_next = ltoh32(fat_entry);
@@ -768,10 +768,10 @@ uint8_t fat_free_clusters(struct fat_fs_struct* fs, cluster_t cluster_num)
         while(cluster_num)
         {
             if(!fs->partition->device_read(fat_offset + (offset_t) cluster_num * sizeof(fat_entry), (uint8_t*) &fat_entry, sizeof(fat_entry)))
-	    {
-		fat_errno = sd_errno;
+            {
+                fat_errno = sd_errno;
                 return 0;
-	    }
+            }
 
             /* get next cluster of current cluster before freeing current cluster */
             uint16_t cluster_num_next = ltoh16(fat_entry);
@@ -884,9 +884,9 @@ uint8_t fat_clear_cluster(const struct fat_fs_struct* fs, cluster_t cluster_num)
  */
 uintptr_t fat_clear_cluster_callback(uint8_t* buffer, offset_t offset, void* p)
 {
-	(void)buffer;
-	(void)offset;
-	(void)p;
+    (void)buffer;
+    (void)offset;
+    (void)p;
     return 16;
 }
 #endif
@@ -1043,8 +1043,8 @@ void fat_close_file(struct fat_file_struct* fd)
     {
 #if FAT_DELAY_DIRENTRY_UPDATE
         /* write directory entry */
-	if (fd->needs_write)
-	      fat_write_dir_entry(fd->fs, &fd->dir_entry);
+        if (fd->needs_write)
+            fat_write_dir_entry(fd->fs, &fd->dir_entry);
 #endif
 
 #if USE_DYNAMIC_MEMORY
@@ -1072,7 +1072,7 @@ intptr_t fat_read_file(struct fat_file_struct* fd, uint8_t* buffer, uintptr_t bu
     /* check arguments */
     if(!fd || !buffer || buffer_len < 1)
     {
-	fat_errno = FAT_ERR_EINVAL;
+        fat_errno = FAT_ERR_EINVAL;
         return -1;
     }
     fat_errno = 0;
@@ -1099,10 +1099,10 @@ intptr_t fat_read_file(struct fat_file_struct* fd, uint8_t* buffer, uintptr_t bu
             if(!fd->pos)
                 return 0;
             else
-	    {
-		fat_errno = FAT_ERR_BAD;
+            {
+                fat_errno = FAT_ERR_BAD;
                 return -1;
-	    }
+            }
         }
 
         if(fd->pos)
@@ -1113,7 +1113,7 @@ intptr_t fat_read_file(struct fat_file_struct* fd, uint8_t* buffer, uintptr_t bu
                 pos -= cluster_size;
                 cluster_num = fat_get_next_cluster(fd->fs, cluster_num);
                 if(!cluster_num)
-		    // fd_errno handled by fat_get_next_cluster()
+                    // fd_errno handled by fat_get_next_cluster()
                     return -1;
             }
         }
@@ -1130,17 +1130,17 @@ intptr_t fat_read_file(struct fat_file_struct* fd, uint8_t* buffer, uintptr_t bu
 
         /* read data */
         if(!fd->fs->partition->device_read(cluster_offset, buffer, copy_length))
-	{
-	    // Original fat.c code did
+        {
+            // Original fat.c code did
             //   return buffer_len - buffer_left;
-	    // and thus failed to alert to a read error in the event that the first
-	    // data read failed.  On the first data read, buffer_len == buffer_left
-	    // and so a failure then would indicate EOF...  Sigh.
-	    if ( sd_errno == 0 )
-		return buffer_len - buffer_left;
-	    fat_errno = sd_errno;
-	    return -1;
-	}
+            // and thus failed to alert to a read error in the event that the first
+            // data read failed.  On the first data read, buffer_len == buffer_left
+            // and so a failure then would indicate EOF...  Sigh.
+            if ( sd_errno == 0 )
+                return buffer_len - buffer_left;
+            fat_errno = sd_errno;
+            return -1;
+        }
 
         /* calculate new file position */
         buffer += copy_length;
@@ -1186,7 +1186,7 @@ intptr_t fat_write_file(struct fat_file_struct* fd, const uint8_t* buffer, uintp
     /* check arguments */
     if(!fd || !buffer || buffer_len < 1 || fd->pos > fd->dir_entry.file_size)
     {
-	fat_errno = FAT_ERR_EINVAL;
+        fat_errno = FAT_ERR_EINVAL;
         return -1;
     }
 
@@ -1207,14 +1207,14 @@ intptr_t fat_write_file(struct fat_file_struct* fd, const uint8_t* buffer, uintp
                 /* empty file */
                 fd->dir_entry.cluster = cluster_num = fat_append_clusters(fd->fs, 0, 1);
                 if(!cluster_num)
-		{
-		    fat_errno = FAT_ERR_FILESYSFULL;
-		    return -1;
-		}
+                {
+                    fat_errno = FAT_ERR_FILESYSFULL;
+                    return -1;
+                }
             }
             else
             {
-		fat_errno = FAT_ERR_BAD;
+                fat_errno = FAT_ERR_BAD;
                 return -1;
             }
         }
@@ -1228,21 +1228,21 @@ intptr_t fat_write_file(struct fat_file_struct* fd, const uint8_t* buffer, uintp
                 pos -= cluster_size;
                 cluster_num_next = fat_get_next_cluster(fd->fs, cluster_num);
                 if(!cluster_num_next)
-		{
-		    if (pos != 0)
-		    {
-			fat_errno = FAT_ERR_BAD;
-			return -1; /* current file position points beyond end of file */
-		    }
+                {
+                    if (pos != 0)
+                    {
+                        fat_errno = FAT_ERR_BAD;
+                        return -1; /* current file position points beyond end of file */
+                    }
 
                     /* the file exactly ends on a cluster boundary, and we append to it */
                     cluster_num_next = fat_append_clusters(fd->fs, cluster_num, 1);
-		    if(!cluster_num_next)
-		    {
-			fat_errno = FAT_ERR_FILESYSFULL;
-			return -1;
-		    }
-		}
+                    if(!cluster_num_next)
+                    {
+                        fat_errno = FAT_ERR_FILESYSFULL;
+                        return -1;
+                    }
+                }
 
                 cluster_num = cluster_num_next;
             }
@@ -1310,7 +1310,7 @@ intptr_t fat_write_file(struct fat_file_struct* fd, const uint8_t* buffer, uintp
             fd->pos = size_old;
         }
 #else
-	fd->needs_write = 1;
+        fd->needs_write = 1;
 #endif
     }
 
@@ -2436,7 +2436,7 @@ void fat_set_file_modification_date(struct fat_dir_entry_struct* dir_entry, uint
 #endif
 
 offset_t fat_get_file_size(const struct fat_file_struct* fd){
-	return fd->dir_entry.file_size;
+    return fd->dir_entry.file_size;
 }
 
 
@@ -2542,7 +2542,7 @@ uint8_t fat_get_fs_free_16_callback(uint8_t* buffer, offset_t offset, void* p)
     struct fat_usage_count_callback_arg* count_arg = (struct fat_usage_count_callback_arg*) p;
     uintptr_t buffer_size = count_arg->buffer_size;
 
-	(void)offset;
+    (void)offset;
 
     for(uintptr_t i = 0; i < buffer_size; i += 2, buffer += 2)
     {
@@ -2564,7 +2564,7 @@ uint8_t fat_get_fs_free_32_callback(uint8_t* buffer, offset_t offset, void* p)
     struct fat_usage_count_callback_arg* count_arg = (struct fat_usage_count_callback_arg*) p;
     uintptr_t buffer_size = count_arg->buffer_size;
 
-	(void)offset;
+    (void)offset;
 
     for(uintptr_t i = 0; i < buffer_size; i += 4, buffer += 4)
     {

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/fat.c
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/fat.c
@@ -348,15 +348,10 @@ uint8_t fat_read_header(struct fat_fs_struct* fs)
         return 0;
     }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
     uint16_t bytes_per_sector = read16(&buffer[0x00]);
     uint16_t reserved_sectors = read16(&buffer[0x03]);
-#pragma GCC diagnostic pop
     uint8_t sectors_per_cluster = buffer[0x02];
     uint8_t fat_copies = buffer[0x05];
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
     uint16_t max_root_entries = read16(&buffer[0x06]);
     uint16_t sector_count_16 = read16(&buffer[0x08]);
     uint16_t sectors_per_fat = read16(&buffer[0x0b]);
@@ -365,7 +360,6 @@ uint8_t fat_read_header(struct fat_fs_struct* fs)
     uint32_t sectors_per_fat32 = read32(&buffer[0x19]);
     uint32_t cluster_root_dir = read32(&buffer[0x21]);
 #endif
-#pragma GCC diagnostic pop
 
     if(sector_count == 0)
     {
@@ -2070,8 +2064,6 @@ uint8_t fat_write_dir_entry(const struct fat_fs_struct* fs, struct fat_dir_entry
     /* fill directory entry buffer */
     memset(&buffer[11], 0, sizeof(buffer) - 11);
     buffer[0x0b] = dir_entry->attributes;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #if FAT_DATETIME_SUPPORT || FAT_DATETIME_PRESERVE
     write16(&buffer[0x16], dir_entry->modification_time);
     write16(&buffer[0x18], dir_entry->modification_date);
@@ -2081,7 +2073,6 @@ uint8_t fat_write_dir_entry(const struct fat_fs_struct* fs, struct fat_dir_entry
 #endif
     write16(&buffer[0x1a], dir_entry->cluster);
     write32(&buffer[0x1c], dir_entry->file_size);
-#pragma GCC diagnostic pop
 
     /* write to disk */
 #if FAT_LFN_SUPPORT

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/fat.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/fat.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2012 by Roland Riegel <feedback@roland-riegel.de>
  * Modifications Copyright (c) 2013 by Dan Newman <dan.newman@mtbaldy.us>
  *
  * This file is free software; you can redistribute it and/or modify

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/fat.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/fat.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2010 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
  * Modifications Copyright (c) 2013 by Dan Newman <dan.newman@mtbaldy.us>
  *
  * This file is free software; you can redistribute it and/or modify
@@ -121,8 +121,10 @@ uint8_t fat_reset_dir(struct fat_dir_struct* dd);
 
 uint8_t fat_create_file(struct fat_dir_struct* parent, const char* file, struct fat_dir_entry_struct* dir_entry);
 uint8_t fat_delete_file(struct fat_fs_struct* fs, struct fat_dir_entry_struct* dir_entry);
+uint8_t fat_move_file(struct fat_fs_struct* fs, struct fat_dir_entry_struct* dir_entry, struct fat_dir_struct* parent_new, const char* file_new);
 uint8_t fat_create_dir(struct fat_dir_struct* parent, const char* dir, struct fat_dir_entry_struct* dir_entry);
 #define fat_delete_dir fat_delete_file
+#define fat_move_dir fat_move_file
 
 void fat_get_file_modification_date(const struct fat_dir_entry_struct* dir_entry, uint16_t* year, uint8_t* month, uint8_t* day);
 void fat_get_file_modification_time(const struct fat_dir_entry_struct* dir_entry, uint8_t* hour, uint8_t* min, uint8_t* sec);

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/fat_config.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/fat_config.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2012 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/fat_config.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/fat_config.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2010 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/partition.c
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/partition.c
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2012 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/partition.c
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/partition.c
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2010 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2
@@ -9,6 +9,7 @@
  */
 
 #include "Compat.hh"
+#include "byteordering.h"
 #include "partition.h"
 #include "partition_config.h"
 #include "sd-reader_config.h"
@@ -111,14 +112,8 @@ struct partition_struct* partition_open(device_read_t device_read, device_read_i
     if(index >= 0)
     {
         new_partition->type = buffer[4];
-        new_partition->offset = ((uint32_t) buffer[8]) |
-                                ((uint32_t) buffer[9] << 8) |
-                                ((uint32_t) buffer[10] << 16) |
-                                ((uint32_t) buffer[11] << 24);
-        new_partition->length = ((uint32_t) buffer[12]) |
-                                ((uint32_t) buffer[13] << 8) |
-                                ((uint32_t) buffer[14] << 16) |
-                                ((uint32_t) buffer[15] << 24);
+        new_partition->offset = read32(&buffer[8]);
+        new_partition->length = read32(&buffer[12]);
     }
     else
     {

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/partition.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/partition.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2012 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/partition.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/partition.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2010 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/partition_config.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/partition_config.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2012 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/partition_config.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/partition_config.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2010 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/sd-reader_config.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/sd-reader_config.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2012 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/sd-reader_config.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/sd-reader_config.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2006-2010 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw.c
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2010 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw.c
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2012 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2
@@ -1105,7 +1105,7 @@ uint8_t sd_raw_get_info(struct sd_raw_info* info)
     {
         uint8_t b = sd_raw_rec_byte();
 
-    if(i == 0)
+        if(i == 0)
         {
 #if SD_RAW_SDHC
             csd_structure = b >> 6;
@@ -1170,7 +1170,6 @@ uint8_t sd_raw_get_info(struct sd_raw_info* info)
                         csd_c_size_mult |= b >> 7;
 
                         info->capacity = (uint32_t) csd_c_size << (csd_c_size_mult + csd_read_bl_len + 2);
-
                         break;
                 }
             }

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw.c
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw.c
@@ -243,7 +243,7 @@ uint8_t sd_raw_init(bool use_crc, uint8_t speed)
     /* Check SD card detect pin */
     if(!sd_raw_available())
     {
-	sd_errno = SDR_ERR_NOCARD;
+        sd_errno = SDR_ERR_NOCARD;
         return 0;
     }
 
@@ -268,18 +268,18 @@ uint8_t sd_raw_init(bool use_crc, uint8_t speed)
         if(i == 0x1ff)
         {
             unselect_card();
-	    sd_errno = SDR_ERR_COMMS;
+            sd_errno = SDR_ERR_COMMS;
             return 0;
         }
     }
 
 #if !SD_RAW_SAVE_RAM
     if ( sd_use_crc ) {
-	if ( sd_raw_send_command(CMD_CRC_ON_OFF, 1) != (1 << R1_IDLE_STATE) ) {
-	    unselect_card();
-	    sd_errno = SDR_ERR_CRC;
-	    return 0;
-	}
+        if ( sd_raw_send_command(CMD_CRC_ON_OFF, 1) != (1 << R1_IDLE_STATE) ) {
+            unselect_card();
+            sd_errno = SDR_ERR_CRC;
+            return 0;
+        }
     }
 #endif
 
@@ -291,15 +291,15 @@ uint8_t sd_raw_init(bool use_crc, uint8_t speed)
         sd_raw_rec_byte();
         sd_raw_rec_byte();
         if((sd_raw_rec_byte() & 0x01) == 0)
-	{
-	    sd_errno = SDR_ERR_VOLTAGE;
+        {
+            sd_errno = SDR_ERR_VOLTAGE;
             return 0; /* card operation voltage range doesn't match */
-	}
+        }
         if(sd_raw_rec_byte() != 0xaa)
-	{
-	    sd_errno = SDR_ERR_PATTERN;
+        {
+            sd_errno = SDR_ERR_PATTERN;
             return 0; /* wrong test pattern */
-	}
+        }
 
         /* card conforms to SD 2 card specification */
         sd_raw_card_type |= (1 << SD_RAW_SPEC_2);
@@ -345,7 +345,7 @@ uint8_t sd_raw_init(bool use_crc, uint8_t speed)
         if(i == 0x1ff)
         {
             unselect_card();
-	    sd_errno = SDR_ERR_COMMS;
+            sd_errno = SDR_ERR_COMMS;
             return 0;
         }
     }
@@ -356,7 +356,7 @@ uint8_t sd_raw_init(bool use_crc, uint8_t speed)
         if(sd_raw_send_command(CMD_READ_OCR, 0))
         {
             unselect_card();
-	    sd_errno = SDR_ERR_BADRESPONSE;
+            sd_errno = SDR_ERR_BADRESPONSE;
             return 0;
         }
 
@@ -369,12 +369,11 @@ uint8_t sd_raw_init(bool use_crc, uint8_t speed)
     }
 #endif
 
-
     /* set block size to 512 bytes */
     if(sd_raw_send_command(CMD_SET_BLOCKLEN, 512))
     {
         unselect_card();
-	sd_errno = SDR_ERR_BADRESPONSE;
+        sd_errno = SDR_ERR_BADRESPONSE;
         return 0;
     }
 
@@ -384,12 +383,12 @@ uint8_t sd_raw_init(bool use_crc, uint8_t speed)
     /* switch to highest SPI frequency possible */
 #if SD_POOR_DESIGN
     if(speed <= 6) {
-	 spi_rate = speed;
-	 spi_init(speed);
+        spi_rate = speed;
+        spi_init(speed);
     }
     else {
-	sd_errno = SDR_ERR_COMMS;
-	return 0;
+        sd_errno = SDR_ERR_COMMS;
+        return 0;
     }
 #else
     // MBI used to use f_OSC / 2
@@ -447,29 +446,26 @@ uint8_t sd_raw_locked()
 void sd_raw_send_byte(uint8_t b)
 {
     uint8_t tries = 0;
-
-    //PORTC |= 0x02;
     SPDR = b;
     /* wait for byte to be shifted out */
     while(!(SPSR & (1 << SPIF)) && (tries++ < 100))
-	_delay_us(1);
-    //PORTC &= ~0x02;
+        _delay_us(1);
     SPSR &= ~(1 << SPIF);
 }
 
 bool sd_start_block()
 {
-     int16_t tries = 0;
-     while ( sd_raw_rec_byte() != 0xfe ) {
-	  if ( ++tries >= 0x7fff )
-	       return false;
-     }
-     return true;
+    int16_t tries = 0;
+    while ( sd_raw_rec_byte() != 0xfe ) {
+        if ( ++tries >= 0x7fff )
+            return false;
+    }
+    return true;
 
-//     uint8_t c;
-//     while ( ((c = sd_raw_rec_byte()) == 0xff) && tries++ < 0x7fff )
-//	  _delay_us(1);
-//     return c == 0xfe;
+//    uint8_t c;
+//    while ( ((c = sd_raw_rec_byte()) == 0xff) && tries++ < 0x7fff )
+//        _delay_us(1);
+//    return c == 0xfe;
 }
 
 /**
@@ -483,12 +479,10 @@ uint8_t sd_raw_rec_byte()
 {
     uint8_t tries = 0;
     /* send dummy data for receiving some */
-    //PORTC |= 0x01;
     SPDR = 0xff;
     while(!(SPSR & (1 << SPIF)) && (tries++ < 100))
-	_delay_us(1);
+        _delay_us(1);
 
-    //PORTC &= ~0x01;
     SPSR &= ~(1 << SPIF);
 
     return SPDR;
@@ -512,30 +506,30 @@ uint8_t sd_raw_send_command(uint8_t command, uint32_t arg)
 
 #if !SD_RAW_SAVE_RAM
     if ( sd_use_crc ) {
-	uint8_t crc[6] = { static_cast<uint8_t>(command | 0x40), args[3], args[2], args[1], args[0] };
-	crc[5] = sd_crc7(crc, 5);
-	for (uint8_t i = 0; i < 6; i++)
-	    sd_raw_send_byte(crc[i]);
+    uint8_t crc[6] = { static_cast<uint8_t>(command | 0x40), args[3], args[2], args[1], args[0] };
+    crc[5] = sd_crc7(crc, 5);
+    for (uint8_t i = 0; i < 6; i++)
+        sd_raw_send_byte(crc[i]);
     }
     else {
 #endif
-	/* send command via SPI */
-	sd_raw_send_byte(0x40 | command);
-	for (int8_t i = 3; i >= 0; i--)
-	    sd_raw_send_byte(args[i]);
+    /* send command via SPI */
+    sd_raw_send_byte(0x40 | command);
+    for (int8_t i = 3; i >= 0; i--)
+        sd_raw_send_byte(args[i]);
 
-	switch(command)
-	{
+    switch(command)
+    {
         case CMD_GO_IDLE_STATE:
-	    sd_raw_send_byte(0x95);
-	    break;
+        sd_raw_send_byte(0x95);
+        break;
         case CMD_SEND_IF_COND:
-	    sd_raw_send_byte(0x87);
-	    break;
+        sd_raw_send_byte(0x87);
+        break;
         default:
-	    sd_raw_send_byte(0xff);
-	    break;
-	}
+        sd_raw_send_byte(0xff);
+        break;
+    }
 #if !SD_RAW_SAVE_RAM
     }
 #endif
@@ -572,14 +566,13 @@ uint8_t sd_raw_read(offset_t offset, uint8_t* buffer, uintptr_t length)
 
     while(length > 0)
     {
-
         /* determine byte count to read at once */
         block_offset = offset & 0x01ff;
         block_address = offset - block_offset;
         read_length = 512 - block_offset; /* read up to block border */
-	// ???? what if read_length == 0
-	if(read_length == 0)
-	     return 0;
+        // ???? what if read_length == 0
+        if(read_length == 0)
+            return 0;
         if(read_length > length)
             read_length = length;
 
@@ -593,9 +586,9 @@ uint8_t sd_raw_read(offset_t offset, uint8_t* buffer, uintptr_t length)
                 return 0;
 #endif
 
-	read_block:
+        read_block:
             /* address card */
-	    SELECT_CARD();
+            SELECT_CARD();
 
             /* send single block request */
 #if SD_RAW_SDHC
@@ -605,17 +598,16 @@ uint8_t sd_raw_read(offset_t offset, uint8_t* buffer, uintptr_t length)
 #endif
             {
                 unselect_card();
-		sd_errno = SDR_ERR_BADRESPONSE;
+                sd_errno = SDR_ERR_BADRESPONSE;
                 return 0;
             }
 
             /* wait for data block (start byte 0xfe) */
-	    if(!sd_start_block()) {
-		 unselect_card();
-		 sd_errno = SDR_ERR_COMMS;
-		 return 0;
-	    }
-
+            if(!sd_start_block()) {
+                unselect_card();
+                sd_errno = SDR_ERR_COMMS;
+                return 0;
+            }
 #if SD_RAW_SAVE_RAM
             /* read byte block */
             uint16_t read_to = block_offset + read_length;
@@ -626,9 +618,9 @@ uint8_t sd_raw_read(offset_t offset, uint8_t* buffer, uintptr_t length)
                     *buffer++ = b;
             }
 
-	    /* ignore crc bytes */
-	    sd_raw_rec_byte();
-	    sd_raw_rec_byte();
+            /* ignore crc bytes */
+            sd_raw_rec_byte();
+            sd_raw_rec_byte();
 #else
             /* read byte block */
             uint8_t* cache = raw_block;
@@ -637,31 +629,31 @@ uint8_t sd_raw_read(offset_t offset, uint8_t* buffer, uintptr_t length)
             raw_block_address = block_address;
 
             /* read crc16 */
-	    if ( sd_use_crc ) {
-		uint16_t crc = sd_raw_rec_byte() << 8;
-		crc |= sd_raw_rec_byte();
-		if ( crc != sd_crc16(raw_block, (uint16_t)512) ) {
-		    unselect_card();
-		    if ( ++attempts < 5 ) {
-			sd_raw_rec_byte(); // pause a little
-			goto read_block;
-		    }
-		    sd_errno = SDR_ERR_CRC;
-		    return 0;
-		}
-	    }
-	    else
-	    {
-		/* ignore crc bytes */
-		sd_raw_rec_byte();
-		sd_raw_rec_byte();
-	    }
+            if ( sd_use_crc ) {
+                uint16_t crc = sd_raw_rec_byte() << 8;
+                crc |= sd_raw_rec_byte();
+                if ( crc != sd_crc16(raw_block, (uint16_t)512) ) {
+                    unselect_card();
+                    if ( ++attempts < 5 ) {
+                        sd_raw_rec_byte(); // pause a little
+                        goto read_block;
+                    }
+                    sd_errno = SDR_ERR_CRC;
+                    return 0;
+                }
+            }
+            else
+            {
+                /* ignore crc bytes */
+                sd_raw_rec_byte();
+                sd_raw_rec_byte();
+            }
 
             memcpy(buffer, raw_block + block_offset, read_length);
             buffer += read_length;
 #endif
 
-	    /* deaddress card */
+            /* deaddress card */
             unselect_card();
 
             /* let card some time to finish */
@@ -712,7 +704,6 @@ uint8_t sd_raw_read_interval(offset_t offset, uint8_t* buffer, uintptr_t interva
     if(!buffer || interval == 0 || length < interval || !callback)
         return 0;
 
-
 #if !SD_RAW_SAVE_RAM
     while(length >= interval)
     {
@@ -754,12 +745,12 @@ uint8_t sd_raw_read_interval(offset_t offset, uint8_t* buffer, uintptr_t interva
         }
 
         /* wait for data block (start byte 0xfe) */
-	if(!sd_start_block())
-	{
-	     unselect_card();
-	     sd_errno = SDR_ERR_COMMS;
-	     return 0;
-	}
+        if(!sd_start_block())
+        {
+             unselect_card();
+             sd_errno = SDR_ERR_COMMS;
+             return 0;
+        }
 
         /* read up to the data of interest */
         for(uint16_t i = 0; i < block_offset; ++i)
@@ -799,7 +790,7 @@ uint8_t sd_raw_read_interval(offset_t offset, uint8_t* buffer, uintptr_t interva
 
         offset = offset - block_offset + 512;
 
-	// ?????
+    // ?????
     } while(!finished);
 
     /* deaddress card */
@@ -831,7 +822,7 @@ uint8_t sd_raw_write(offset_t offset, const uint8_t* buffer, uintptr_t length)
 {
     if(sd_raw_locked())
     {
-	sd_errno = SDR_ERR_LOCKED;
+        sd_errno = SDR_ERR_LOCKED;
         return 0;
     }
 
@@ -854,7 +845,7 @@ uint8_t sd_raw_write(offset_t offset, const uint8_t* buffer, uintptr_t length)
         {
 #if SD_RAW_WRITE_BUFFERING
             if(!sd_raw_sync())
-		// sd_raw_sync() calls us back...
+                // sd_raw_sync() calls us back...
                 return 0;
 #endif
 
@@ -879,7 +870,7 @@ uint8_t sd_raw_write(offset_t offset, const uint8_t* buffer, uintptr_t length)
         }
 
         /* address card */
-	SELECT_CARD();
+        SELECT_CARD();
 
         /* send single block request */
 #if SD_RAW_SDHC
@@ -889,7 +880,7 @@ uint8_t sd_raw_write(offset_t offset, const uint8_t* buffer, uintptr_t length)
 #endif
         {
             unselect_card();
-	    sd_errno = SDR_ERR_BADRESPONSE;
+            sd_errno = SDR_ERR_BADRESPONSE;
             return 0;
         }
 
@@ -901,23 +892,23 @@ uint8_t sd_raw_write(offset_t offset, const uint8_t* buffer, uintptr_t length)
         for(uint16_t i = 0; i < 512; ++i)
             sd_raw_send_byte(*cache++);
 
-	uint16_t crc;
-	crc = ( sd_use_crc ) ? sd_crc16(raw_block, (uint16_t)512) : 0xffff;
-	sd_raw_send_byte(crc >> 8);
-	sd_raw_send_byte(crc & 0xff);
+        uint16_t crc;
+        crc = ( sd_use_crc ) ? sd_crc16(raw_block, (uint16_t)512) : 0xffff;
+        sd_raw_send_byte(crc >> 8);
+        sd_raw_send_byte(crc & 0xff);
 
-        /* wait while card is busy */
-	uint16_t tries = 0;
+            /* wait while card is busy */
+        uint16_t tries = 0;
         while(sd_raw_rec_byte() != 0xff)
-	{
-	    // ?????
-	    if(tries++ >= 0x7FFF)
-	    {
-		unselect_card();
-		sd_errno = SDR_ERR_COMMS;
-		return 0;
-	    }
-	}
+        {
+            // ?????
+            if(tries++ >= 0x7FFF)
+            {
+                unselect_card();
+                sd_errno = SDR_ERR_COMMS;
+                return 0;
+            }
+        }
         sd_raw_rec_byte();
 
         /* deaddress card */
@@ -1046,8 +1037,8 @@ uint8_t sd_raw_get_info(struct sd_raw_info* info)
 
     if(!sd_start_block())
     {
-	 unselect_card();
-	 return 0;
+        unselect_card();
+        return 0;
     }
 
     for(uint8_t i = 0; i < 18; ++i)
@@ -1106,15 +1097,15 @@ uint8_t sd_raw_get_info(struct sd_raw_info* info)
 
     if(!sd_start_block())
     {
-	 unselect_card();
-	 return 0;
+        unselect_card();
+        return 0;
     }
 
     for(uint8_t i = 0; i < 18; ++i)
     {
         uint8_t b = sd_raw_rec_byte();
 
-	if(i == 0)
+    if(i == 0)
         {
 #if SD_RAW_SDHC
             csd_structure = b >> 6;

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2012 by Roland Riegel <feedback@roland-riegel.de>
  * Modifications Copyright (c) 2013 by Dan Newman <dan.newman@mtbaldy.us>
  *
  * This file is free software; you can redistribute it and/or modify

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2010 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
  * Modifications Copyright (c) 2013 by Dan Newman <dan.newman@mtbaldy.us>
  *
  * This file is free software; you can redistribute it and/or modify

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw_config.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2010 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw_config.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw_config.h
@@ -115,8 +115,8 @@ extern "C"
 #elif defined(__AVR_ATmega64__) || \
       defined(__AVR_ATmega128__) || \
       defined(__AVR_ATmega169__) || \
-	  defined(__AVR_ATmega1280__) || \
-	  defined(__AVR_ATmega2560__)
+      defined(__AVR_ATmega1280__) || \
+      defined(__AVR_ATmega2560__)
     #define configure_pin_mosi() DDRB |= (1 << DDB2)
     #define configure_pin_sck() DDRB |= (1 << DDB1)
     #define configure_pin_ss() DDRB |= (1 << DDB0)

--- a/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw_config.h
+++ b/firmware/src/MightyBoard/Motherboard/lib_sd/sd_raw_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2011 by Roland Riegel <feedback@roland-riegel.de>
+ * Copyright (c) 2006-2012 by Roland Riegel <feedback@roland-riegel.de>
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2


### PR DESCRIPTION
I went back in the project history to the commit before earliest lib_sd-related change recorded. The state of this code at the time already had changes not seen in the upstream 2010-10-10 release, so I made minor cleanups (spacing, mainly) to minimize the diff with the upstream lib_sd and make the code consistent, then applied each subsequent upstream release as a patch, resolving merge conflicts at each step. I then rebased this work on the latest sailfish source, similarly fixing spacing in the changes that took place in the meantime, and resolved the additional merge conflicts that arose from these later sailfish-originated changes. Finally, I removed warning suppression where upstream had actually resolved the warned-about issue.

This incorporates fully the changes from the upstream lib_sd as found at http://www.roland-riegel.de/sd-reader/ thru the latest (as of this writing) release, 2012-06-12, without removing the improvements/modifications made specific to this firmware.

I have not done extensive testing (I've mostly been printing over USB since having a print fail in the middle with the extruder or at least the heater still going due to a flaky SD reader is not fun), but it seems to work fine on my Replicator 2X - at least as well as it did before. (My motivation was to try to improve reliability of my SD reader - as well as to just help out others with similar machines: no sense in using outdated code when there's improved code available and I know the Git magic to neatly combine upstream changes with in-project changes without too much pain)

Oh, and despite warnings about slight increase in binary size upstream: no substantial increase was seen, it still fits fine in the atmega1280 on my 2X with room to spare: this is what my build size is with these changes, when built with the GCC 5.4.0-based toolchain included with Atmel Studio 7:

```
> avr-size mighty_twox_v7.8.0.en.elf
   text    data     bss     dec     hex filename
 109468    1082    5454  116004   1c524 mighty_twox_v7.8.0.en.elf

> avr-size --format=avr --mcu=atmega1280 mighty_twox_v7.8.0.en.elf
AVR Memory Usage
----------------
Device: atmega1280

Program:  110550 bytes (84.3% Full)
(.text + .data + .bootloader)

Data:       6536 bytes (79.8% Full)
(.data + .bss + .noinit)
```

Using the GCC 4.9.2 toolchain included with the Arduino distribution, it's a few bytes smaller than with 5.4.0:

```
AVR Memory Usage
----------------
Device: atmega1280

Program:  110284 bytes (84.1% Full)
(.text + .data + .bootloader)

Data:       6535 bytes (79.8% Full)
(.data + .bss + .noinit)
```