### PR TITLE
Efficient sd card reading

### DIFF
--- a/firmware/src/MightyBoard/Motherboard/SDCard.hh
+++ b/firmware/src/MightyBoard/Motherboard/SDCard.hh
@@ -26,6 +26,9 @@
 /// listing directory contents, and reading and writing jobs to files.
 namespace sdcard {
 
+    // Size of SD read buffer
+    #define SD_BYTE_BUFLEN 32
+
     /// This enumeration lists all the SD card call error/success codes.
     /// Any non-zero value is an error condition.
     typedef enum {

--- a/firmware/src/MightyBoard/Motherboard/SDCard.hh
+++ b/firmware/src/MightyBoard/Motherboard/SDCard.hh
@@ -26,8 +26,11 @@
 /// listing directory contents, and reading and writing jobs to files.
 namespace sdcard {
 
-    // Size of SD read buffer
-    #define SD_BYTE_BUFLEN 32
+#ifdef PLATFORM_SD_READ_BUFFER
+#define SD_BYTE_BUFLEN PLATFORM_SD_READ_BUFFER
+#else
+#define SD_BYTE_BUFLEN 32
+#endif
 
     /// This enumeration lists all the SD card call error/success codes.
     /// Any non-zero value is an error condition.

--- a/firmware/src/platforms.py
+++ b/firmware/src/platforms.py
@@ -98,6 +98,12 @@ platforms = {
 #                                                        and your bot should be seriously prepared if you rise
 #                                                        Extruder >280 and HBP >130. You are warned now!
 #
+#        PLATFORM_SD_READ_BUFFER     -- Sets size of the SD card read buffer. Tests with an
+#                                       ff_creatorx-2560 show that there seems no benefit to go
+#                                       above the default, but if you're cramming many features in
+#                                       an exotic printer type, maybe it needs to be lowered.
+#                                       (default: 32)
+#
 #   squeeze    -- Source files to compile --mcall-prologues so as to save
 #                 code space.
 


### PR DESCRIPTION
This improves efficiency of SD card reads by buffering them so we don't have to go through the entire FAT table each time to obtain one fresh byte. This considerably reduces certain delays, see issue #200. In cases where SRAM would be tight, the buffer size can be changed in platform.py.