### PR TITLE
True Extra Fan PWM, piggybacking on M70

### DIFF
--- a/firmware/src/MightyBoard/Motherboard/Command.cc
+++ b/firmware/src/MightyBoard/Motherboard/Command.cc
@@ -2014,11 +2014,24 @@ void runCommandSlice() {
 				}
 			}
 			} else if (command == HOST_CMD_SET_BUILD_PERCENT){
+                fan_pwm_enable = false;
+                pop8();
+                fan_pwm_override = true;
+                fan_pwm_override_value = pop8();
+
+                fan_pwm_bottom_count = (255 - (1 << FAN_PWM_BITS)) +
+                                        (int)(0.5 +  ((uint16_t)(1 << FAN_PWM_BITS) * fan_pwm_override_value) / 100.0);
+                pop8();
+                buildPercentage = 1;
+                fan_pwm_enable = true;
+                LINE_NUMBER_INCR;
+                /*
 				if (command_buffer.getLength() >= 3){
 					pop8(); // remove the command code
 					buildPercentage = pop8();
 					pop8();	// uint8_t ignore; // remove the reserved byte
 					LINE_NUMBER_INCR;
+                    */
 #if defined(BUILD_STATS) || defined(ESTIMATE_TIME)
 					//Set the starting time / percent on the first HOST_CMD_SET_BUILD_PERCENT
 					//with a non zero value sent near the start of the build
@@ -2031,7 +2044,7 @@ void runCommandSlice() {
 						elapsedSecondsSinceBuildStart = host::getPrintSeconds();
 					}
 #endif
-				}
+				// }
 			} else if (command == HOST_CMD_QUEUE_SONG ) //queue a song for playing
  			{
 				/// Error tone is 0,

--- a/firmware/src/MightyBoard/Motherboard/Motherboard.cc
+++ b/firmware/src/MightyBoard/Motherboard/Motherboard.cc
@@ -95,8 +95,10 @@ static bool heating_lights_active;
 
 #if defined(COOLING_FAN_PWM)
 #define FAN_PWM_BITS 6
-static uint8_t fan_pwm_bottom_count;
+uint8_t fan_pwm_bottom_count;
 bool           fan_pwm_enable = false;
+bool           fan_pwm_override = false;
+uint8_t        fan_pwm_override_value = 100;
 #endif
 
 #if defined(PSTOP_ZMIN_LEVEL)
@@ -1019,8 +1021,12 @@ void Motherboard::setExtra(bool on) {
 
      // See what the PWM setting is -- may have been changed
      ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-	  fan_pwm = (uint16_t)eeprom::getEeprom8(eeprom_offsets::COOLING_FAN_DUTY_CYCLE,
+        if ( fan_pwm_override ) {
+            fan_pwm = (uint16_t)fan_pwm_override_value;
+        } else {
+	    fan_pwm = (uint16_t)eeprom::getEeprom8(eeprom_offsets::COOLING_FAN_DUTY_CYCLE,
 						 COOLING_FAN_DUTY_CYCLE_DEFAULT);
+        }
      }
 
      // Don't bother with PWM handling if the PWM is >= 100

--- a/firmware/src/MightyBoard/Motherboard/Motherboard.hh
+++ b/firmware/src/MightyBoard/Motherboard/Motherboard.hh
@@ -54,7 +54,11 @@
 #endif
 
 #if defined(COOLING_FAN_PWM)
+#define FAN_PWM_BITS 6
+extern uint8_t fan_pwm_bottom_count;
 extern bool fan_pwm_enable;
+extern bool fan_pwm_override;
+extern uint8_t fan_pwm_override_value;
 #endif
 
 #ifdef DEBUG_VALUE


### PR DESCRIPTION
This is yet another solution to the problem of getting an analog controllable part cooling fan.

It works on stock hardware (well, if you have a mosfet soldered to the Extra port) and without patching GPX, but you'll need a slicer that allows you to specify which gcode command to use for the fan. To set it up in your slicer, just tell it to send `M70 P{fan percentage} (F)` (i.e. so that the slicer generates `M70 P100 (F)` for a fan running at full throttle).

It does this by piggybacking on `M70` (Display Message). If the Message to be displayed is simply `F`, the duration parameter is instead interpreted as the duty cycle, in percent, of the fan.

Do realize that this is a hack (I think display message is a different priority from the movement commands, so the timing of your fan toggles might not be 100% synced to when you expect it to happen). and that it likely won't be merged, but I've been running this for over a year wanted to share my work with the world.