### PR TITLE
Live Extrusion factor control from LCD

### DIFF
--- a/firmware/build.sh
+++ b/firmware/build.sh
@@ -20,7 +20,7 @@ fi
 VER=`awk -F'.' '{printf("%d.%d.%d",$1,$2,$3); exit}' $FWDIR/current_version.txt`
 SCONS="scons -j${JOBS:-4}"
 
-for BUILD in `python src/platforms.py`
+for BUILD in `python2 src/platforms.py`
 do
 
     rm -rf build/$BUILD

--- a/firmware/src/MightyBoard/Motherboard/Command.cc
+++ b/firmware/src/MightyBoard/Motherboard/Command.cc
@@ -743,8 +743,10 @@ static void handleMovementCommand(const uint8_t &command) {
 			int32_t y = pop32();
 			int32_t z = pop32();
 			int32_t a = pop32();
+			if ( steppers::alterExtrusion ) a = FPTOI(FPMULT2(steppers::extrusionFactor, ITOFP(a)));
 #if EXTRUDERS > 1
 			int32_t b = pop32();
+			if ( steppers::alterExtrusion ) b = FPTOI(FPMULT2(steppers::extrusionFactor, ITOFP(b)));
 #else
 			pop32();
 #endif
@@ -781,6 +783,10 @@ static void handleMovementCommand(const uint8_t &command) {
 			int32_t z = pop32();
 			int32_t a = pop32();
 			int32_t b = pop32();
+			if ( steppers::alterExtrusion ) {
+				a = FPTOI(FPMULT2(steppers::extrusionFactor, ITOFP(a)));
+				b = FPTOI(FPMULT2(steppers::extrusionFactor, ITOFP(b)));
+			}
 			int32_t us = pop32();
 			uint8_t relative = pop8();
 
@@ -832,6 +838,10 @@ static void handleMovementCommand(const uint8_t &command) {
 			int32_t z = pop32();
 			int32_t a = pop32();
 			int32_t b = pop32();
+			if ( steppers::alterExtrusion ) {
+				a = FPTOI(FPMULT2(steppers::extrusionFactor, ITOFP(a)));
+				b = FPTOI(FPMULT2(steppers::extrusionFactor, ITOFP(b)));
+			}
 			int32_t dda_rate = pop32();
 			uint8_t relative = pop8() & 0x7F; // make sure that the high bit is clear
 			int32_t distanceInt32 = pop32();

--- a/firmware/src/MightyBoard/Motherboard/StepperAccelPlanner.hh
+++ b/firmware/src/MightyBoard/Motherboard/StepperAccelPlanner.hh
@@ -62,6 +62,7 @@
 	//Various constants we need, we preconvert these to fixed point to save time later
 	#define KCONSTANT_MINUS_0_95	-62259		//ftok(-0.95)
         #define KCONSTANT_0_001         65              //ftok(0.001)
+	#define KCONSTANT_0_01		655		//ftok(0.01)
 	#define KCONSTANT_0_05          3276            //ftok(0.05)
 	#define KCONSTANT_0_1		6553		//ftok(0.1)
 	#define KCONSTANT_0_25		16384		//ftok(0.25)
@@ -131,6 +132,7 @@
 	//Various constants we need, we preconvert these to fixed point to save time later
 	#define KCONSTANT_MINUS_0_95	-0.95
         #define KCONSTANT_0_001         0.001
+	#define KCONSTANT_0_01		0.01
 	#define KCONSTANT_0_05          0.05
 	#define KCONSTANT_0_1		0.1
 	#define KCONSTANT_0_25		0.25

--- a/firmware/src/MightyBoard/Motherboard/Steppers.cc
+++ b/firmware/src/MightyBoard/Motherboard/Steppers.cc
@@ -79,7 +79,9 @@ int16_t tolerance_feedrate_x64;
 namespace steppers {
 
 uint8_t alterSpeed = 0x00;
+uint8_t alterExtrusion = 0x00;
 FPTYPE speedFactor = KCONSTANT_1;
+FPTYPE extrusionFactor = KCONSTANT_1;
 
 #if defined(DIGIPOT_SUPPORT)
 

--- a/firmware/src/MightyBoard/Motherboard/Steppers.hh
+++ b/firmware/src/MightyBoard/Motherboard/Steppers.hh
@@ -45,9 +45,11 @@ namespace steppers {
     extern bool acceleration;
     extern bool extruder_hold[EXTRUDERS];
     extern uint8_t alterSpeed;
+    extern uint8_t alterExtrusion;
     extern uint8_t toolIndex;
     extern FPTYPE axis_steps_per_unit_inverse[STEPPER_COUNT];
     extern FPTYPE speedFactor;
+    extern FPTYPE extrusionFactor;
 
     /// Check if the stepper subsystem is running
     /// \return True if the stepper subsystem is running or paused. False

--- a/firmware/src/MightyBoard/shared/Menu.cc
+++ b/firmware/src/MightyBoard/shared/Menu.cc
@@ -2800,12 +2800,10 @@ void ChangeExtrusionScreen::notifyButtonPressed(ButtonArray::ButtonName button) 
 		interface::popScreen();
 		return;
 	case ButtonArray::UP:
-		// increment less
-		ef += KCONSTANT_0_05;
+		ef += KCONSTANT_0_01;
 		break;
 	case ButtonArray::DOWN:
-		// decrement less
-		ef -= KCONSTANT_0_05;
+		ef -= KCONSTANT_0_01;
 		break;
 	default:
 		return;
@@ -3256,6 +3254,12 @@ void ActiveBuildMenu::handleSelect(uint8_t index) {
 		lind++;
 	}
 
+	if ( index == lind ) {
+		interface::pushScreen(&changeExtrusionScreen);
+		return;
+	}
+
+	lind++;
 	if ( index == lind ) {
 		interface::pushScreen(&changeSpeedScreen);
 		return;

--- a/firmware/src/MightyBoard/shared/Menu.hh
+++ b/firmware/src/MightyBoard/shared/Menu.hh
@@ -328,6 +328,25 @@ public:
 
 #endif // AUTO_LEVEL
 
+
+class ChangeExtrusionScreen: public Screen {
+
+private:
+	FPTYPE  extrusionFactor;
+	uint8_t alterExtrusion;
+
+public:
+        ChangeExtrusionScreen(): Screen(_BV((uint8_t)ButtonArray::UP) | _BV((uint8_t)ButtonArray::DOWN)) {}
+
+	micros_t getUpdateRate() {return 50L * 1000L;}
+
+        void update(LiquidCrystalSerial& lcd, bool forceRedraw);
+
+        void reset();
+
+        void notifyButtonPressed(ButtonArray::ButtonName button);
+};
+
 class ChangeSpeedScreen: public Screen {
 
 private:

--- a/firmware/src/MightyBoard/shared/locale/Menu.DE.cc
+++ b/firmware/src/MightyBoard/shared/locale/Menu.DE.cc
@@ -176,6 +176,7 @@ const PROGMEM prog_uchar DITTO_PRINT_MSG[]         = "Doppeldruck";
 //#endif
 const PROGMEM prog_uchar PAUSEATZPOS_MSG[]         = "Pause bei ZPos";
 const PROGMEM prog_uchar CHANGE_SPEED_MSG[]        = "Aendere Speed";
+const PROGMEM prog_uchar CHANGE_EXTRUSION_MSG[]    = "Flussregulat.";
 const PROGMEM prog_uchar CHANGE_TEMP_MSG[]         = "Aendere Temperatur";
 const PROGMEM prog_uchar CHANGE_HBP_TEMP_MSG[]     = "Aendere HBP Temp";
 const PROGMEM prog_uchar FAN_ON_MSG[]              = "Set Cooling Fan ON "; // Needs trailing space

--- a/firmware/src/MightyBoard/shared/locale/Menu.EN.cc
+++ b/firmware/src/MightyBoard/shared/locale/Menu.EN.cc
@@ -149,6 +149,7 @@ const PROGMEM prog_uchar DISABLED_MSG[]            = "N/A";
 const PROGMEM prog_uchar DITTO_PRINT_MSG[]         = "Ditto Printing";
 //#endif
 const PROGMEM prog_uchar PAUSEATZPOS_MSG[]	   = "Pause at ZPos";
+const PROGMEM prog_uchar CHANGE_EXTRUSION_MSG[]    = "Change Extr.";
 const PROGMEM prog_uchar CHANGE_SPEED_MSG[]        = "Change Speed";
 const PROGMEM prog_uchar CHANGE_TEMP_MSG[]         = "Change Temperature";
 const PROGMEM prog_uchar CHANGE_HBP_TEMP_MSG[]     = "Change HBP Temp";

--- a/firmware/src/MightyBoard/shared/locale/Menu.EN.cc
+++ b/firmware/src/MightyBoard/shared/locale/Menu.EN.cc
@@ -149,7 +149,7 @@ const PROGMEM prog_uchar DISABLED_MSG[]            = "N/A";
 const PROGMEM prog_uchar DITTO_PRINT_MSG[]         = "Ditto Printing";
 //#endif
 const PROGMEM prog_uchar PAUSEATZPOS_MSG[]	   = "Pause at ZPos";
-const PROGMEM prog_uchar CHANGE_EXTRUSION_MSG[]    = "Change Extr.";
+const PROGMEM prog_uchar CHANGE_EXTRUSION_MSG[]    = "Change Extrusion";
 const PROGMEM prog_uchar CHANGE_SPEED_MSG[]        = "Change Speed";
 const PROGMEM prog_uchar CHANGE_TEMP_MSG[]         = "Change Temperature";
 const PROGMEM prog_uchar CHANGE_HBP_TEMP_MSG[]     = "Change HBP Temp";

--- a/firmware/src/MightyBoard/shared/locale/Menu.FR.cc
+++ b/firmware/src/MightyBoard/shared/locale/Menu.FR.cc
@@ -134,6 +134,7 @@ const PROGMEM prog_uchar DITTO_PRINT_MSG[]         = "Impression identique";
 //#endif
 const PROGMEM prog_uchar PAUSEATZPOS_MSG[]	        = "Pause a ZPos";
 const PROGMEM prog_uchar CHANGE_SPEED_MSG[]        = "Changer la vitesse";
+const PROGMEM prog_uchar CHANGE_EXTRUSION_MSG[]    = "Changer ecoulement";
 const PROGMEM prog_uchar CHANGE_TEMP_MSG[]         = "Changer Temperature";
 const PROGMEM prog_uchar CHANGE_HBP_TEMP_MSG[]     = "Changer Temp. HBP";
 const PROGMEM prog_uchar FAN_ON_MSG[]              = "Activer ventilateur"; // Needs trailing space

--- a/firmware/src/MightyBoard/shared/locale/locale.hh
+++ b/firmware/src/MightyBoard/shared/locale/locale.hh
@@ -157,6 +157,7 @@ extern const unsigned char DISABLED_MSG[];
 extern const unsigned char DITTO_PRINT_MSG[];
 #endif
 extern const unsigned char PAUSEATZPOS_MSG[];
+extern const unsigned char CHANGE_EXTRUSION_MSG[];
 extern const unsigned char CHANGE_SPEED_MSG[];
 extern const unsigned char CHANGE_TEMP_MSG[];
 extern const unsigned char CHANGE_HBP_TEMP_MSG[];


### PR DESCRIPTION
I got fed up with powerlessly watching over- or underextruding prints turn themselves to mush. This lets you set a global factor for all extruder movements. This *does* also affect retractions (since there's no easy way of differentiating retraction from non retraction movements), so diverging too far from 1.0 will probably introduce some stringing, but since stringing is *much* easier to correct post-printing than overextrusion, this shouldn't be much of a problem.